### PR TITLE
feat: add SSH terminal access support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,19 @@ async with ClientSession() as session:
 
     await client.push_button(ButtonType.POWER, duration_ms=1000)
 ```
+
+## SSH Usage
+
+```python
+from nanokvm.ssh_client import NanoKVMSSH
+
+# Create SSH client
+ssh = NanoKVMSSH("kvm-8b76.local")
+await ssh.authenticate("password")
+
+# Run commands
+uptime = await ssh.run_command("cat /proc/uptime")
+disk = await ssh.run_command("df -h /")
+
+await ssh.disconnect()
+```

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -28,7 +28,9 @@ class NanoKVMSSHCommandError(NanoKVMSSHError):
 class NanoKVMSSH:
     """SSH client for NanoKVM terminal access."""
 
-    def __init__(self, host: str, username: str = DEFAULT_SSH_USERNAME, port: int = 22) -> None:
+    def __init__(
+        self, host: str, username: str = DEFAULT_SSH_USERNAME, port: int = 22
+    ) -> None:
         """Initialize the SSH client."""
         self.host = host
         self.port = port
@@ -42,9 +44,10 @@ class NanoKVMSSH:
         self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         try:
+            client = self.ssh_client  # Capture for lambda
             await loop.run_in_executor(
                 None,
-                lambda: self.ssh_client.connect(
+                lambda: client.connect(
                     self.host,
                     port=self.port,
                     username=self.username,
@@ -53,9 +56,9 @@ class NanoKVMSSH:
                 )
             )
         except paramiko.AuthenticationException as e:
-            raise NanoKVMSSHAuthenticationError(f"SSH authentication failed: {e}")
+            raise NanoKVMSSHAuthenticationError(f"SSH authentication failed: {e}") from e
         except (paramiko.SSHException, paramiko.BadHostKeyException, OSError) as e:
-            raise NanoKVMSSHAuthenticationError(f"SSH connection failed: {e}")
+            raise NanoKVMSSHAuthenticationError(f"SSH connection failed: {e}") from e
 
     async def disconnect(self) -> None:
         """Close SSH connection."""
@@ -66,7 +69,9 @@ class NanoKVMSSH:
     async def run_command(self, command: str, timeout: int = 30) -> str:
         """Run a command via SSH and return output."""
         if not self.ssh_client:
-            raise NanoKVMSSHNotConnectedError("SSH not connected, call authenticate first")
+            raise NanoKVMSSHNotConnectedError(
+                "SSH not connected, call authenticate first"
+            )
         loop = asyncio.get_running_loop()
         try:
             output, error = await asyncio.wait_for(
@@ -81,10 +86,11 @@ class NanoKVMSSH:
         except asyncio.TimeoutError:
             raise NanoKVMSSHCommandError(
                 f"SSH command timed out after {timeout} seconds"
-            )
+            ) from None
 
     def _exec_command_sync(self, command: str) -> tuple[str, str]:
         """Synchronous SSH command execution."""
+        assert self.ssh_client is not None  # Should be set after authenticate()
         stdin, stdout, stderr = self.ssh_client.exec_command(command)
         output = stdout.read().decode('utf-8')
         error = stderr.read().decode('utf-8')

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -56,9 +56,13 @@ class NanoKVMSSH:
                 )
             )
         except paramiko.AuthenticationException as e:
-            raise NanoKVMSSHAuthenticationError(f"SSH authentication failed: {e}") from e
+            raise NanoKVMSSHAuthenticationError(
+                f"SSH authentication failed: {e}"
+            ) from e
         except (paramiko.SSHException, paramiko.BadHostKeyException, OSError) as e:
-            raise NanoKVMSSHAuthenticationError(f"SSH connection failed: {e}") from e
+            raise NanoKVMSSHAuthenticationError(
+                f"SSH connection failed: {e}"
+            ) from e
 
     async def disconnect(self) -> None:
         """Close SSH connection."""

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -77,9 +77,7 @@ class NanoKVMSSH:
         loop = asyncio.get_running_loop()
         try:
             output, error = await asyncio.wait_for(
-                loop.run_in_executor(
-                    None, self._exec_command_sync, command
-                ),
+                loop.run_in_executor(None, self._exec_command_sync, command),
                 timeout=timeout,
             )
             if error:

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -6,10 +6,12 @@ import asyncio
 
 import paramiko
 
+from .client import NanoKVMError
+
 DEFAULT_SSH_USERNAME = "root"
 
 
-class NanoKVMSSHError(Exception):
+class NanoKVMSSHError(NanoKVMError):
     """Base exception for SSH client errors."""
 
 

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -53,7 +53,7 @@ class NanoKVMSSH:
                     username=self.username,
                     password=password,
                     timeout=10,
-                )
+                ),
             )
         except paramiko.AuthenticationException as e:
             raise NanoKVMSSHAuthenticationError(

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -1,0 +1,91 @@
+"""SSH client for NanoKVM terminal access."""
+
+from __future__ import annotations
+
+import asyncio
+
+import paramiko
+
+DEFAULT_SSH_USERNAME = "root"
+
+
+class NanoKVMSSHError(Exception):
+    """Base exception for SSH client errors."""
+
+
+class NanoKVMSSHNotConnectedError(NanoKVMSSHError):
+    """Exception for when SSH client is not connected."""
+
+
+class NanoKVMSSHAuthenticationError(NanoKVMSSHError):
+    """Exception for SSH authentication failures."""
+
+
+class NanoKVMSSHCommandError(NanoKVMSSHError):
+    """Exception for SSH command execution errors."""
+
+
+class NanoKVMSSH:
+    """SSH client for NanoKVM terminal access."""
+
+    def __init__(self, host: str, username: str = DEFAULT_SSH_USERNAME, port: int = 22) -> None:
+        """Initialize the SSH client."""
+        self.host = host
+        self.port = port
+        self.username = username
+        self.ssh_client: paramiko.SSHClient | None = None
+
+    async def authenticate(self, password: str) -> None:
+        """Authenticate with SSH using password."""
+        loop = asyncio.get_running_loop()
+        self.ssh_client = paramiko.SSHClient()
+        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        try:
+            await loop.run_in_executor(
+                None,
+                lambda: self.ssh_client.connect(
+                    self.host,
+                    port=self.port,
+                    username=self.username,
+                    password=password,
+                    timeout=10
+                )
+            )
+        except paramiko.AuthenticationException as e:
+            raise NanoKVMSSHAuthenticationError(f"SSH authentication failed: {e}")
+        except (paramiko.SSHException, paramiko.BadHostKeyException, OSError) as e:
+            raise NanoKVMSSHAuthenticationError(f"SSH connection failed: {e}")
+
+    async def disconnect(self) -> None:
+        """Close SSH connection."""
+        if self.ssh_client:
+            self.ssh_client.close()
+            self.ssh_client = None
+
+    async def run_command(self, command: str, timeout: int = 30) -> str:
+        """Run a command via SSH and return output."""
+        if not self.ssh_client:
+            raise NanoKVMSSHNotConnectedError("SSH not connected, call authenticate first")
+        loop = asyncio.get_running_loop()
+        try:
+            output, error = await asyncio.wait_for(
+                loop.run_in_executor(
+                    None, self._exec_command_sync, command
+                ),
+                timeout=timeout
+            )
+            if error:
+                raise NanoKVMSSHCommandError(f"SSH command error: {error}")
+            return output.strip()
+        except asyncio.TimeoutError:
+            raise NanoKVMSSHCommandError(
+                f"SSH command timed out after {timeout} seconds"
+            )
+
+    def _exec_command_sync(self, command: str) -> tuple[str, str]:
+        """Synchronous SSH command execution."""
+        stdin, stdout, stderr = self.ssh_client.exec_command(command)
+        output = stdout.read().decode('utf-8')
+        error = stderr.read().decode('utf-8')
+        return output, error

--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -52,7 +52,7 @@ class NanoKVMSSH:
                     port=self.port,
                     username=self.username,
                     password=password,
-                    timeout=10
+                    timeout=10,
                 )
             )
         except paramiko.AuthenticationException as e:
@@ -60,9 +60,7 @@ class NanoKVMSSH:
                 f"SSH authentication failed: {e}"
             ) from e
         except (paramiko.SSHException, paramiko.BadHostKeyException, OSError) as e:
-            raise NanoKVMSSHAuthenticationError(
-                f"SSH connection failed: {e}"
-            ) from e
+            raise NanoKVMSSHAuthenticationError(f"SSH connection failed: {e}") from e
 
     async def disconnect(self) -> None:
         """Close SSH connection."""
@@ -82,7 +80,7 @@ class NanoKVMSSH:
                 loop.run_in_executor(
                     None, self._exec_command_sync, command
                 ),
-                timeout=timeout
+                timeout=timeout,
             )
             if error:
                 raise NanoKVMSSHCommandError(f"SSH command error: {error}")
@@ -96,6 +94,6 @@ class NanoKVMSSH:
         """Synchronous SSH command execution."""
         assert self.ssh_client is not None  # Should be set after authenticate()
         stdin, stdout, stderr = self.ssh_client.exec_command(command)
-        output = stdout.read().decode('utf-8')
-        error = stderr.read().decode('utf-8')
+        output = stdout.read().decode("utf-8")
+        error = stderr.read().decode("utf-8")
         return output, error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "yarl",
     "pillow",
     "pydantic",
+    "paramiko",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
__Add SSH Terminal Access Support__

This PR adds SSH terminal access functionality to the NanoKVM Python client, providing an independent SSH client alongside the existing HTTP API client.

### __New Features__

#### __NanoKVMSSH Class__

A new generic SSH client that allows executing commands on the NanoKVM device:

```python
from nanokvm.ssh_client import NanoKVMSSH

# Create SSH client
ssh = NanoKVMSSH("kvm-host")
await ssh.authenticate("password")

# Execute commands and get raw output
uptime = await ssh.run_command("cat /proc/uptime")
disk = await ssh.run_command("df -k")

await ssh.disconnect()
```

#### __Key Features:__

- __Independent Authentication__ - SSH and HTTP auth are completely separate
- __Generic Command Execution__ - Returns raw command output
- __Async/Await Support__ - Full asyncio compatibility with timeout handling

### __Architecture:__

- __Separation of Concerns__ - HTTP client handles API calls, SSH client handles terminal access
- __Generic Design__ - SSH client returns raw output, letting users parse as needed
- __Backwards Compatible__ - No changes to existing HTTP API functionality

### __Usage Examples__

```python
# HTTP API (existing functionality - unchanged)
from nanokvm.client import NanoKVMClient

# SSH access (new functionality)
from nanokvm.ssh_client import NanoKVMSSH

# They work independently
http_client = NanoKVMClient("http://kvm/api", session)
ssh_client = NanoKVMSSH("kvm-host")
```

### __Dependencies__

- Added `paramiko` for SSH functionality

---

This provides users with both __structured API access__ (HTTP) and __direct terminal access__ (SSH) to their NanoKVM devices, making the library more versatile for different use cases.
