### PR TITLE
fix: correct ButtonType reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Async Python client for [NanoKVM](https://github.com/sipeed/NanoKVM).
 ```python
 
 from aiohttp import ClientSession
-from nanokvm.models import ButtonType
+from nanokvm.models import GpioType
 from nanokvm.client import NanoKVMClient
 
 
@@ -24,5 +24,5 @@ async with ClientSession() as session:
     async for frame in client.mjpeg_stream():
         print(frame)
 
-    await client.push_button(ButtonType.POWER, duration_ms=1000)
+    await client.push_button(GpioType.POWER, duration_ms=1000)
 ```


### PR DESCRIPTION
__Fix ButtonType reference in README__

Corrects `ButtonType` to `GpioType` in the README.md usage example, as `ButtonType` doesn't exist in the library.