### PR TITLE
fix: add support for nanokvm pro

### DIFF
--- a/nanokvm/models.py
+++ b/nanokvm/models.py
@@ -91,6 +91,7 @@ class HWVersion(StrEnum):
     ALPHA = "Alpha"
     BETA = "Beta"
     PCIE = "PCIE"
+    PRO = "Pro"
     UNKNOWN = "Unknown"
 
 


### PR DESCRIPTION
```
GET /api/vm/hardware
{"code":0,"msg":"success","data":{"version":"Pro"}}# 
```

can confirm both Desk and ATX variants respond with `Pro`