### PR TITLE
python: downgrade to python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 dependencies = [
     "aiohttp",
     "cryptography",


### PR DESCRIPTION
I want to ask that we reduce the minimum python requirement to 3.11 for compatibility.

Keeping the requirement to 3.13 makes it incompatible with our current plans to use it from https://jumpstarter.dev, see [1].

i.e. current ubuntu LTS: 3.12, fedora 42 already ships 3.13, centos10 ships python 3.12

[1] https://github.com/jumpstarter-dev/jumpstarter/pull/771