### PR TITLE
Add hostname support (GET/POST)

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -28,6 +28,7 @@ from .models import (
     GetHardwareRsp,
     GetHdmiStateRsp,
     GetHidModeRsp,
+    GetHostnameRsp,
     GetImagesRsp,
     GetInfoRsp,
     GetMdnsStateRsp,
@@ -54,6 +55,7 @@ from .models import (
     PasteReq,
     SetGpioReq,
     SetHidModeReq,
+    SetHostnameReq,
     SetMemoryLimitReq,
     SetMouseJigglerReq,
     SetOledReq,
@@ -321,6 +323,22 @@ class NanoKVMClient:
             hdrs.METH_GET,
             "/vm/hardware",
             response_model=GetHardwareRsp,
+        )
+
+    async def get_hostname(self) -> GetHostnameRsp:
+        """Get the configured hostname."""
+        return await self._api_request_json(
+            hdrs.METH_GET,
+            "/vm/hostname",
+            response_model=GetHostnameRsp,
+        )
+
+    async def set_hostname(self, hostname: str) -> None:
+        """Set the device hostname (applies after reboot)."""
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/vm/hostname",
+            data=SetHostnameReq(hostname=hostname),
         )
 
     async def get_gpio(self) -> GetGpioRsp:

--- a/nanokvm/models.py
+++ b/nanokvm/models.py
@@ -160,6 +160,14 @@ class GetInfoRsp(BaseModel):
     device_key: str = Field(alias="deviceKey")
 
 
+class GetHostnameRsp(BaseModel):
+    hostname: str
+
+
+class SetHostnameReq(BaseModel):
+    hostname: str  # Applies after reboot
+
+
 class GetHardwareRsp(BaseModel):
     version: HWVersion
 


### PR DESCRIPTION
## Summary
This PR adds hostname endpoint support to the Python NanoKVM client.

## Changes
- Added `GET /vm/hostname` support via `get_hostname()`
- Added `POST /vm/hostname` support via `set_hostname(hostname)`
- Added typed models:
  - `GetHostnameRsp`
  - `SetHostnameReq`

## Notes
- `SetHostnameReq.hostname` includes the note that the change applies after reboot.
