### PR TITLE
Nanokvm pro api coverage

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -843,7 +843,7 @@ class NanoKVMClient:
 
     @require_hardware(HWVersion.ALPHA, HWVersion.BETA, HWVersion.PCIE)
     async def set_screen(self, setting: ScreenSettingType, value: int) -> None:
-        """Set a legacy NanoKVM screen setting."""
+        """Set a non-Pro NanoKVM screen setting."""
         await self._api_request_json(
             hdrs.METH_POST,
             "/vm/screen",
@@ -875,7 +875,7 @@ class NanoKVMClient:
         except aiohttp.ClientResponseError as err:
             if err.status == 404:
                 raise NanoKVMNotSupportedError(
-                    "enable_swap is unavailable on this legacy hardware/firmware"
+                    "enable_swap is unavailable on this non-Pro hardware/firmware"
                 ) from err
             raise
 
@@ -887,7 +887,7 @@ class NanoKVMClient:
         except aiohttp.ClientResponseError as err:
             if err.status == 404:
                 raise NanoKVMNotSupportedError(
-                    "disable_swap is unavailable on this legacy hardware/firmware"
+                    "disable_swap is unavailable on this non-Pro hardware/firmware"
                 ) from err
             raise
 

--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -9,6 +9,8 @@ import functools
 import io
 import json
 import logging
+from os import PathLike
+from pathlib import Path
 import ssl
 from typing import Any, TypeVar, overload
 
@@ -26,11 +28,15 @@ from pydantic import BaseModel, ValidationError
 import yarl
 
 from .models.common import (
+    AddShortcutReq,
     ApiResponse,
     ApiResponseCode,
     ChangePasswordReq,
     ConnectWifiReq,
     DeleteImageReq,
+    DeleteMacReq,
+    DeleteScriptReq,
+    DeleteShortcutReq,
     DownloadImageReq,
     GetAccountRsp,
     GetGpioRsp,
@@ -39,14 +45,19 @@ from .models.common import (
     GetHostnameRsp,
     GetImagesRsp,
     GetInfoRsp,
+    GetLeaderKeyRsp,
+    GetMacRsp,
     GetMdnsStateRsp,
     GetMountedImageRsp,
     GetMouseJigglerRsp,
     GetOLEDRsp,
     GetPreviewRsp,
+    GetScriptsRsp,
+    GetShortcutsRsp,
     GetSSHStateRsp,
     GetTailscaleStatusRsp,
     GetVersionRsp,
+    GetVirtualDeviceRsp,
     GetWebTitleRsp,
     GetWifiRsp,
     GpioType,
@@ -56,19 +67,27 @@ from .models.common import (
     IsPasswordUpdatedRsp,
     LoginReq,
     LoginRsp,
+    LoginTailscaleRsp,
     MountImageReq,
     MouseButton,
     MouseJigglerMode,
     PasteReq,
+    RunScriptReq,
+    RunScriptRsp,
+    RunScriptType,
     SetGpioReq,
     SetHidModeReq,
     SetHostnameReq,
+    SetLeaderKeyReq,
+    SetMacNameReq,
     SetMouseJigglerReq,
     SetOledReq,
     SetPreviewReq,
     SetWebTitleReq,
+    ShortcutKey,
     StatusImageRsp,
     UpdateVirtualDeviceReq,
+    UploadScriptRsp,
     VirtualDevice,
     WakeOnLANReq,
 )
@@ -77,13 +96,15 @@ from .models.non_pro import (
     GetHdmiStateRsp,
     GetMemoryLimitRsp,
     GetSwapSizeRsp,
-    GetVirtualDeviceRsp,
+    ScreenSettingType,
     SetMemoryLimitReq,
+    SetScreenReq,
     SetSwapSizeReq,
 )
 from .models.pro import (
     DeleteEdidReq,
     DiskType,
+    EdidValue,
     GetCustomEdidListRsp,
     GetEdidRsp,
     GetHdmiCaptureRsp,
@@ -96,7 +117,7 @@ from .models.pro import (
     GetStaticIPRsp,
     GetTimeStatusRsp,
     GetTimeZoneRsp,
-    GetVirtualDeviceProRsp,
+    LcdTimeFormat,
     RateControlMode,
     RefreshVirtualDeviceReq,
     ScanWifiRsp,
@@ -113,7 +134,9 @@ from .models.pro import (
     SetStreamModeReq,
     SetStreamQualityReq,
     SetTimeZoneReq,
+    StreamMode,
     SwitchEdidReq,
+    UploadEdidRsp,
 )
 from .utils import obfuscate_password
 
@@ -323,12 +346,15 @@ class NanoKVMClient:
         assert self._session is not None
         assert self._ssl_config is not None
 
+        request_headers = {
+            hdrs.ACCEPT: "application/json",
+            **kwargs.pop("headers", {}),
+        }
+
         async with self._session.request(
             method,
             self.url / path.lstrip("/"),
-            headers={
-                hdrs.ACCEPT: "application/json",
-            },
+            headers=request_headers,
             cookies=cookies,
             timeout=aiohttp.ClientTimeout(total=self._request_timeout),
             raise_for_status=True,
@@ -381,16 +407,79 @@ class NanoKVMClient:
             try:
                 raw_response = await response.json(content_type=None)
                 _LOGGER.debug("Raw JSON response data: %s", raw_response)
-                # Parse the outer ApiResponse structure
-                api_response = ApiResponse[response_model].model_validate(raw_response)  # type: ignore
             except (json.JSONDecodeError, ValidationError) as err:
                 raise NanoKVMInvalidResponseError(
                     f"Invalid JSON response received: {err}"
                 ) from err
 
+        return self._validate_api_response(raw_response, response_model)
+
+    @overload
+    async def _api_request_form(
+        self,
+        method: str,
+        path: str,
+        response_model: type[T],
+        data: aiohttp.FormData,
+        **kwargs: Any,
+    ) -> T: ...
+
+    @overload
+    async def _api_request_form(
+        self,
+        method: str,
+        path: str,
+        response_model: None = None,
+        data: aiohttp.FormData | None = None,
+        **kwargs: Any,
+    ) -> None: ...
+
+    async def _api_request_form(
+        self,
+        method: str,
+        path: str,
+        response_model: type[T] | None = None,
+        data: aiohttp.FormData | None = None,
+        **kwargs: Any,
+    ) -> T | None:
+        """Make API request with multipart/form data and parse JSON response."""
+        _LOGGER.debug("Making API form request: %s %s", method, path)
+
+        async with self._request(
+            method,
+            path,
+            data=data,
+            **kwargs,
+        ) as response:
+            try:
+                raw_response = await response.json(content_type=None)
+                _LOGGER.debug("Raw JSON response data: %s", raw_response)
+            except (json.JSONDecodeError, ValidationError) as err:
+                raise NanoKVMInvalidResponseError(
+                    f"Invalid JSON response received: {err}"
+                ) from err
+
+        return self._validate_api_response(raw_response, response_model)
+
+    def _validate_api_response(
+        self,
+        raw_response: Any,
+        response_model: type[T] | None = None,
+    ) -> T | None:
+        """Validate the shared NanoKVM response envelope."""
+        try:
+            if response_model is None:
+                api_response = ApiResponse[Any].model_validate(raw_response)
+            else:
+                api_response = ApiResponse[response_model].model_validate(raw_response)  # type: ignore[valid-type]
+        except ValidationError as err:
+            raise NanoKVMInvalidResponseError(
+                f"Invalid JSON response received: {err}"
+            ) from err
+
         _LOGGER.debug("Got API response: %s", api_response)
 
-        if api_response.code != ApiResponseCode.SUCCESS:
+        if api_response.code != ApiResponseCode.SUCCESS.value:
             raise NanoKVMApiError(
                 f"API returned error: {api_response.msg} (Code: {api_response.code})",
                 code=api_response.code,
@@ -398,7 +487,49 @@ class NanoKVMClient:
                 data=api_response.data,
             )
 
+        if response_model is None:
+            return None
+
         return api_response.data
+
+    @overload
+    async def _upload_file(
+        self,
+        path: str,
+        file_path: str | PathLike[str],
+        response_model: type[T],
+        **kwargs: Any,
+    ) -> T: ...
+
+    @overload
+    async def _upload_file(
+        self,
+        path: str,
+        file_path: str | PathLike[str],
+        response_model: None = None,
+        **kwargs: Any,
+    ) -> None: ...
+
+    async def _upload_file(
+        self,
+        path: str,
+        file_path: str | PathLike[str],
+        response_model: type[T] | None = None,
+        **kwargs: Any,
+    ) -> T | None:
+        """Upload a file using the NanoKVM multipart API."""
+        upload_path = Path(file_path)
+        form = aiohttp.FormData()
+
+        with upload_path.open("rb") as file_obj:
+            form.add_field("file", file_obj, filename=upload_path.name)
+            return await self._api_request_form(
+                hdrs.METH_POST,
+                path,
+                response_model=response_model,
+                data=form,
+                **kwargs,
+            )
 
     # ── Authentication ──────────────────────────────────────────────────
 
@@ -423,7 +554,7 @@ class NanoKVMClient:
 
             self._token = login_response.token
         except NanoKVMApiError as err:
-            if err.code == ApiResponseCode.INVALID_USERNAME_OR_PASSWORD:
+            if err.code == ApiResponseCode.INVALID_USERNAME_OR_PASSWORD.value:
                 raise NanoKVMAuthenticationFailure(
                     "Invalid username or password"
                 ) from err
@@ -445,12 +576,14 @@ class NanoKVMClient:
             _LOGGER.debug("Auto-detecting password mode")
             try:
                 await self._do_authenticate(username, obfuscate_password(password))
+                self._use_password_obfuscation = True
                 _LOGGER.info("Auto-detected obfuscated password mode")
             except NanoKVMAuthenticationFailure:
                 _LOGGER.debug(
                     "Obfuscated authentication failed, trying plain text password"
                 )
                 await self._do_authenticate(username, password)
+                self._use_password_obfuscation = False
                 _LOGGER.info("Auto-detected plain text password mode")
 
         await self.detect_hardware()
@@ -467,12 +600,24 @@ class NanoKVMClient:
 
     async def change_password(self, username: str, new_password: str) -> None:
         """Change the KVM password."""
+        if self._use_password_obfuscation is None:
+            raise ValueError(
+                "Password mode is unknown. Authenticate first or set "
+                "use_password_obfuscation explicitly before changing the password."
+            )
+
+        password_to_send = (
+            obfuscate_password(new_password)
+            if self._use_password_obfuscation
+            else new_password
+        )
+
         await self._api_request_json(
             hdrs.METH_POST,
             "/auth/password",
             data=ChangePasswordReq(
                 username=username,
-                password=obfuscate_password(new_password),
+                password=password_to_send,
             ),
         )
 
@@ -534,6 +679,39 @@ class NanoKVMClient:
             response_model=GetGpioRsp,
         )
 
+    async def get_scripts(self) -> GetScriptsRsp:
+        """Get the list of uploaded scripts."""
+        return await self._api_request_json(
+            hdrs.METH_GET,
+            "/vm/script",
+            response_model=GetScriptsRsp,
+        )
+
+    async def upload_script(self, file_path: str | PathLike[str]) -> UploadScriptRsp:
+        """Upload a script file."""
+        return await self._upload_file(
+            "/vm/script/upload",
+            file_path,
+            response_model=UploadScriptRsp,
+        )
+
+    async def run_script(self, name: str, script_type: RunScriptType) -> RunScriptRsp:
+        """Run an uploaded script."""
+        return await self._api_request_json(
+            hdrs.METH_POST,
+            "/vm/script/run",
+            response_model=RunScriptRsp,
+            data=RunScriptReq(name=name, type=script_type),
+        )
+
+    async def delete_script(self, name: str) -> None:
+        """Delete an uploaded script."""
+        await self._api_request_json(
+            hdrs.METH_DELETE,
+            "/vm/script",
+            data=DeleteScriptReq(name=name),
+        )
+
     async def push_button(self, button: GpioType, duration_ms: int) -> None:
         """Simulate pushing a hardware button."""
         await self._api_request_json(
@@ -590,19 +768,12 @@ class NanoKVMClient:
             data=SetOledReq(sleep=sleep_seconds),
         )
 
-    async def get_virtual_device_status(
-        self,
-    ) -> GetVirtualDeviceRsp | GetVirtualDeviceProRsp:
+    async def get_virtual_device_status(self) -> GetVirtualDeviceRsp:
         """Get the status of virtual devices."""
-        model = (
-            GetVirtualDeviceProRsp
-            if self._hw_version == HWVersion.PRO
-            else GetVirtualDeviceRsp
-        )
         return await self._api_request_json(
             hdrs.METH_GET,
             "/vm/device/virtual",
-            response_model=model,
+            response_model=GetVirtualDeviceRsp,
         )
 
     async def update_virtual_device(
@@ -633,6 +804,10 @@ class NanoKVMClient:
         self, enabled: bool, mode: MouseJigglerMode
     ) -> None:
         """Set the mouse jiggler state."""
+        current = await self.get_mouse_jiggler_state()
+        if current.enabled == enabled and (not enabled or current.mode == mode):
+            return
+
         await self._api_request_json(
             hdrs.METH_POST,
             "/vm/mouse-jiggler/",
@@ -659,7 +834,21 @@ class NanoKVMClient:
         """Reboot the KVM device."""
         await self._api_request_json(hdrs.METH_POST, "/vm/system/reboot")
 
+    @require_hardware(HWVersion.PRO)
+    async def switch_to_pikvm(self) -> None:
+        """Switch the system image to PiKVM."""
+        await self._api_request_json(hdrs.METH_POST, "/vm/system/pikvm")
+
     # ── VM (non-Pro only) ──────────────────────────────────────────────
+
+    @require_hardware(HWVersion.ALPHA, HWVersion.BETA, HWVersion.PCIE)
+    async def set_screen(self, setting: ScreenSettingType, value: int) -> None:
+        """Set a legacy NanoKVM screen setting."""
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/vm/screen",
+            data=SetScreenReq(type=setting, value=value),
+        )
 
     @require_hardware(HWVersion.ALPHA, HWVersion.BETA, HWVersion.PCIE)
     async def get_swap_size(self) -> int:
@@ -681,12 +870,26 @@ class NanoKVMClient:
     @require_hardware(HWVersion.ALPHA, HWVersion.BETA, HWVersion.PCIE)
     async def enable_swap(self) -> None:
         """Enable swap."""
-        await self._api_request_json(hdrs.METH_POST, "/vm/swap/enable")
+        try:
+            await self._api_request_json(hdrs.METH_POST, "/vm/swap/enable")
+        except aiohttp.ClientResponseError as err:
+            if err.status == 404:
+                raise NanoKVMNotSupportedError(
+                    "enable_swap is unavailable on this legacy hardware/firmware"
+                ) from err
+            raise
 
     @require_hardware(HWVersion.ALPHA, HWVersion.BETA, HWVersion.PCIE)
     async def disable_swap(self) -> None:
         """Disable swap."""
-        await self._api_request_json(hdrs.METH_POST, "/vm/swap/disable")
+        try:
+            await self._api_request_json(hdrs.METH_POST, "/vm/swap/disable")
+        except aiohttp.ClientResponseError as err:
+            if err.status == 404:
+                raise NanoKVMNotSupportedError(
+                    "disable_swap is unavailable on this legacy hardware/firmware"
+                ) from err
+            raise
 
     @require_hardware(HWVersion.ALPHA, HWVersion.BETA, HWVersion.PCIE)
     async def get_memory_limit(self) -> GetMemoryLimitRsp:
@@ -751,7 +954,7 @@ class NanoKVMClient:
         )
 
     @require_hardware(HWVersion.PRO)
-    async def set_lcd_time_format(self, fmt: str) -> None:
+    async def set_lcd_time_format(self, fmt: LcdTimeFormat | str) -> None:
         """Set the LCD time format (12h/24h)."""
         await self._api_request_json(
             hdrs.METH_POST,
@@ -805,7 +1008,7 @@ class NanoKVMClient:
         )
 
     @require_hardware(HWVersion.PRO)
-    async def switch_edid(self, edid: str) -> None:
+    async def switch_edid(self, edid: EdidValue) -> None:
         """Switch EDID."""
         await self._api_request_json(
             hdrs.METH_POST,
@@ -820,6 +1023,15 @@ class NanoKVMClient:
             hdrs.METH_GET,
             "/vm/edid/custom",
             response_model=GetCustomEdidListRsp,
+        )
+
+    @require_hardware(HWVersion.PRO)
+    async def upload_edid(self, file_path: str | PathLike[str]) -> UploadEdidRsp:
+        """Upload a custom EDID."""
+        return await self._upload_file(
+            "/vm/edid/upload",
+            file_path,
+            response_model=UploadEdidRsp,
         )
 
     @require_hardware(HWVersion.PRO)
@@ -862,12 +1074,39 @@ class NanoKVMClient:
     async def set_led_strip(
         self,
         *,
-        on: bool,
-        horizontal_count: int,
-        vertical_count: int,
-        brightness: int,
+        on: bool | None = None,
+        horizontal_count: int | None = None,
+        vertical_count: int | None = None,
+        brightness: int | None = None,
     ) -> None:
         """Set LED strip configuration."""
+        if all(
+            value is None
+            for value in (on, horizontal_count, vertical_count, brightness)
+        ):
+            raise ValueError("At least one LED strip setting must be provided")
+
+        if any(
+            value is None
+            for value in (on, horizontal_count, vertical_count, brightness)
+        ):
+            current = await self.get_led_strip()
+            on = current.on if on is None else on
+            horizontal_count = (
+                current.horizontal_count
+                if horizontal_count is None
+                else horizontal_count
+            )
+            vertical_count = (
+                current.vertical_count if vertical_count is None else vertical_count
+            )
+            brightness = current.brightness if brightness is None else brightness
+
+        assert on is not None
+        assert horizontal_count is not None
+        assert vertical_count is not None
+        assert brightness is not None
+
         await self._api_request_json(
             hdrs.METH_POST,
             "/vm/ledstrip/set",
@@ -937,6 +1176,46 @@ class NanoKVMClient:
             hdrs.METH_GET,
             "/hid/mode",
             response_model=GetHidModeRsp,
+        )
+
+    async def get_shortcuts(self) -> GetShortcutsRsp:
+        """Get configured custom HID shortcuts."""
+        return await self._api_request_json(
+            hdrs.METH_GET,
+            "/hid/shortcuts",
+            response_model=GetShortcutsRsp,
+        )
+
+    async def add_shortcut(self, keys: list[ShortcutKey]) -> None:
+        """Add a custom HID shortcut."""
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/hid/shortcut",
+            data=AddShortcutReq(keys=keys),
+        )
+
+    async def delete_shortcut(self, shortcut_id: str) -> None:
+        """Delete a custom HID shortcut."""
+        await self._api_request_json(
+            hdrs.METH_DELETE,
+            "/hid/shortcut",
+            data=DeleteShortcutReq(id=shortcut_id),
+        )
+
+    async def get_leader_key(self) -> GetLeaderKeyRsp:
+        """Get the configured shortcut leader key."""
+        return await self._api_request_json(
+            hdrs.METH_GET,
+            "/hid/shortcut/leader-key",
+            response_model=GetLeaderKeyRsp,
+        )
+
+    async def set_leader_key(self, key: str = "") -> None:
+        """Set or clear the shortcut leader key."""
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/hid/shortcut/leader-key",
+            data=SetLeaderKeyReq(key=key),
         )
 
     async def set_hid_mode(self, mode: HidMode) -> None:
@@ -1033,6 +1312,31 @@ class NanoKVMClient:
             data=ConnectWifiReq(ssid=ssid, password=password),
         )
 
+    async def connect_wifi_no_auth(
+        self,
+        ssid: str,
+        password: str = "",
+        ap_password: str | None = None,
+    ) -> None:
+        """Connect to WiFi while the device is in AP-mode setup flow."""
+        headers = {"X-AP-Key": ap_password} if ap_password is not None else {}
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/network/wifi",
+            authenticate=False,
+            headers=headers,
+            data=ConnectWifiReq(ssid=ssid, password=password),
+        )
+
+    async def verify_ap_login(self, ap_password: str) -> None:
+        """Verify AP-mode setup credentials."""
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/network/wifi/verify",
+            authenticate=False,
+            headers={"X-AP-Key": ap_password},
+        )
+
     async def disconnect_wifi(self) -> None:
         """Disconnect from the current WiFi network."""
         await self._api_request_json(hdrs.METH_POST, "/network/wifi/disconnect")
@@ -1041,6 +1345,38 @@ class NanoKVMClient:
         """Send a Wake-on-LAN packet."""
         await self._api_request_json(
             hdrs.METH_POST, "/network/wol", data=WakeOnLANReq(mac=mac)
+        )
+
+    async def get_wol_macs(self) -> GetMacRsp:
+        """Get saved Wake-on-LAN MAC entries."""
+        try:
+            return await self._api_request_json(
+                hdrs.METH_GET,
+                "/network/wol/mac",
+                response_model=GetMacRsp,
+            )
+        except NanoKVMApiError as err:
+            if (
+                err.code == ApiResponseCode.INVALID_USERNAME_OR_PASSWORD.value
+                and err.msg == "open file error"
+            ):
+                return GetMacRsp()
+            raise
+
+    async def delete_wol_mac(self, mac: str) -> None:
+        """Delete a saved Wake-on-LAN MAC entry."""
+        await self._api_request_json(
+            hdrs.METH_DELETE,
+            "/network/wol/mac",
+            data=DeleteMacReq(mac=mac),
+        )
+
+    async def set_wol_mac_name(self, mac: str, name: str) -> None:
+        """Set the display name for a saved Wake-on-LAN MAC entry."""
+        await self._api_request_json(
+            hdrs.METH_POST,
+            "/network/wol/mac/name",
+            data=SetMacNameReq(mac=mac, name=name),
         )
 
     async def get_tailscale_status(self) -> GetTailscaleStatusRsp:
@@ -1092,12 +1428,13 @@ class NanoKVMClient:
         )
 
     @require_hardware(HWVersion.PRO)
-    async def set_stream_mode(self, mode: str) -> None:
+    async def set_stream_mode(self, mode: StreamMode | str) -> None:
         """Set the stream mode."""
+        stream_mode = mode if isinstance(mode, StreamMode) else StreamMode(mode)
         await self._api_request_json(
             hdrs.METH_POST,
             "/stream/mode",
-            data=SetStreamModeReq(mode=mode),
+            data=SetStreamModeReq(mode=stream_mode),
         )
 
     @require_hardware(HWVersion.PRO)
@@ -1129,11 +1466,11 @@ class NanoKVMClient:
 
     # ── Stream (shared) ────────────────────────────────────────────────
 
-    def _parse_jpeg_from_bytes(self, data: bytes) -> Image:
+    def _parse_jpeg_from_bytes(self, data: bytes) -> Image.Image:
         """Parse JPEG image from bytes."""
         return Image.open(io.BytesIO(data), formats=["JPEG"])
 
-    async def mjpeg_stream(self) -> AsyncIterator[Image]:
+    async def mjpeg_stream(self) -> AsyncIterator[Image.Image]:
         """Stream MJPEG frames."""
         async with self._request(hdrs.METH_GET, "/stream/mjpeg") as response:
             reader = MultipartReader.from_response(response)
@@ -1236,9 +1573,13 @@ class NanoKVMClient:
         """Bring Tailscale down."""
         await self._api_request_json(hdrs.METH_POST, "/extensions/tailscale/down")
 
-    async def tailscale_login(self) -> None:
+    async def tailscale_login(self) -> LoginTailscaleRsp:
         """Log in to Tailscale."""
-        await self._api_request_json(hdrs.METH_POST, "/extensions/tailscale/login")
+        return await self._api_request_json(
+            hdrs.METH_POST,
+            "/extensions/tailscale/login",
+            response_model=LoginTailscaleRsp,
+        )
 
     async def tailscale_logout(self) -> None:
         """Log out of Tailscale."""

--- a/nanokvm/models/common.py
+++ b/nanokvm/models/common.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 from enum import IntEnum, StrEnum
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Self, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 T = TypeVar("T")
 
 
 class ApiResponseCode(IntEnum):
-    """API Response Codes."""
+    """Documented shared API response codes."""
 
     SUCCESS = 0
     FAILURE = -1
@@ -103,11 +103,31 @@ class MouseButton(IntEnum):
     MIDDLE = 4
 
 
+class _CaseInsensitiveStrEnum(StrEnum):
+    """String enum with case-insensitive parsing."""
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        if isinstance(value, str):
+            normalized = value.lower()
+            for member in cls:
+                if member.value.lower() == normalized:
+                    return member
+        return None
+
+
+class OledType(_CaseInsensitiveStrEnum):
+    """OLED variants used by NanoKVM Pro."""
+
+    ATX = "ATX"
+    DESK = "DESK"
+
+
 # Generic Response Wrapper
 class ApiResponse(BaseModel, Generic[T]):
     """Generic API response structure."""
 
-    code: ApiResponseCode
+    code: int
     msg: str
     data: T | None = None
 
@@ -152,8 +172,16 @@ class GetInfoRsp(BaseModel):
     image: str
     application: str
     device_key: str = Field(alias="deviceKey")
-    part_number: str = Field("", alias="pn")  # Pro only
-    arch: str = ""  # Pro only
+    part_number: str | None = Field(default=None, alias="pn")  # Pro only
+    arch: str | None = None  # Pro only
+
+    @field_validator("part_number", "arch", mode="before")
+    @classmethod
+    def _normalize_optional_strings(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
 
 
 class GetHostnameRsp(BaseModel):
@@ -179,7 +207,16 @@ class GetGpioRsp(BaseModel):
 
 
 class GetScriptsRsp(BaseModel):
-    files: list[str]
+    files: list[str] = Field(default_factory=list)
+
+    @field_validator("files", mode="before")
+    @classmethod
+    def _normalize_files(cls, value: Any) -> Any:
+        return [] if value is None else value
+
+
+class UploadScriptRsp(BaseModel):
+    file: str
 
 
 class RunScriptReq(BaseModel):
@@ -202,10 +239,54 @@ class UpdateVirtualDeviceReq(BaseModel):
     type: str | None = None  # Pro only (sdcard/emmc for disk device)
 
 
+class GetVirtualDeviceRsp(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    network: bool = False
+    media: bool | None = None
+    disk: bool | None = None
+    mic: bool | None = None
+    is_network_enabled: bool | None = Field(default=None, alias="isNetworkEnabled")
+    is_mic_enabled: bool | None = Field(default=None, alias="isMicEnabled")
+    mounted_disk: str | None = Field(default=None, alias="mountedDisk")
+    is_sd_card_exist: bool | None = Field(default=None, alias="isSdCardExist")
+    is_emmc_exist: bool | None = Field(default=None, alias="isEmmcExist")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_virtual_device_fields(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        data = dict(value)
+
+        if "network" not in data and "isNetworkEnabled" in data:
+            data["network"] = data["isNetworkEnabled"]
+
+        if "mic" not in data and "isMicEnabled" in data:
+            data["mic"] = data["isMicEnabled"]
+
+        return data
+
+    @field_validator("mounted_disk", mode="before")
+    @classmethod
+    def _normalize_mounted_disk(cls, value: Any) -> Any:
+        if value == "":
+            return None
+        return value
+
+
 class GetOLEDRsp(BaseModel):
     exist: bool
-    type: str = ""  # Pro only
+    type: OledType | None = None  # Pro only
     sleep: int  # Sleep timeout in seconds
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def _normalize_oled_type(cls, value: Any) -> Any:
+        if value == "":
+            return None
+        return value
 
 
 class SetOledReq(BaseModel):
@@ -262,7 +343,12 @@ class Shortcut(BaseModel):
 
 
 class GetShortcutsRsp(BaseModel):
-    shortcuts: list[Shortcut]
+    shortcuts: list[Shortcut] = Field(default_factory=list)
+
+    @field_validator("shortcuts", mode="before")
+    @classmethod
+    def _normalize_shortcuts(cls, value: Any) -> Any:
+        return [] if value is None else value
 
 
 class AddShortcutReq(BaseModel):
@@ -317,7 +403,20 @@ class WakeOnLANReq(BaseModel):
 
 
 class GetMacRsp(BaseModel):
-    macs: list[str]
+    macs: list[str] = Field(default_factory=list)
+
+    @field_validator("macs", mode="before")
+    @classmethod
+    def _normalize_macs(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [
+                item
+                for item in value
+                if not isinstance(item, str) or item.strip()
+            ]
+        return value
 
 
 class DeleteMacReq(BaseModel):
@@ -348,10 +447,23 @@ class GetWifiRsp(BaseModel):
     ssid: str = ""  # Non-Pro only
     wifi: WiFiInfo | None = None  # Pro only
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_wifi_fields(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        data = dict(value)
+        wifi = data.get("wifi")
+        if data.get("ssid") in (None, "") and isinstance(wifi, dict):
+            data["ssid"] = wifi.get("ssid", "")
+
+        return data
+
 
 class ConnectWifiReq(BaseModel):
     ssid: str
-    password: str
+    password: str = ""
 
 
 class GetTailscaleStatusRsp(BaseModel):
@@ -362,7 +474,7 @@ class GetTailscaleStatusRsp(BaseModel):
 
 
 class LoginTailscaleRsp(BaseModel):
-    url: str
+    url: str = ""
 
 
 # Application Models

--- a/nanokvm/models/common.py
+++ b/nanokvm/models/common.py
@@ -411,11 +411,7 @@ class GetMacRsp(BaseModel):
         if value is None:
             return []
         if isinstance(value, list):
-            return [
-                item
-                for item in value
-                if not isinstance(item, str) or item.strip()
-            ]
+            return [item for item in value if not isinstance(item, str) or item.strip()]
         return value
 
 

--- a/nanokvm/models/non_pro.py
+++ b/nanokvm/models/non_pro.py
@@ -22,12 +22,6 @@ class SetScreenReq(BaseModel):
     value: int
 
 
-class GetVirtualDeviceRsp(BaseModel):
-    network: bool
-    media: bool
-    disk: bool
-
-
 class GetMemoryLimitRsp(BaseModel):
     enabled: bool
     limit: int  # In MB

--- a/nanokvm/models/pro.py
+++ b/nanokvm/models/pro.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .common import WiFiInfo
 
@@ -23,15 +24,57 @@ class RateControlMode(StrEnum):
     VBR = "vbr"
 
 
-# VM Models
-class GetVirtualDeviceProRsp(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+class _CaseInsensitiveStrEnum(StrEnum):
+    """String enum with case-insensitive parsing."""
 
-    is_network_enabled: bool = Field(alias="isNetworkEnabled")
-    is_mic_enabled: bool = Field(alias="isMicEnabled")
-    mounted_disk: str = Field(alias="mountedDisk")
-    is_sd_card_exist: bool = Field(alias="isSdCardExist")
-    is_emmc_exist: bool = Field(alias="isEmmcExist")
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        if isinstance(value, str):
+            normalized = value.lower()
+            for member in cls:
+                if member.value.lower() == normalized:
+                    return member
+        return None
+
+
+class StreamMode(StrEnum):
+    """Video stream modes."""
+
+    MJPEG = "mjpeg"
+    H264_WEBRTC = "h264-webrtc"
+    H264_DIRECT = "h264-direct"
+    H265_WEBRTC = "h265-webrtc"
+    H265_DIRECT = "h265-direct"
+
+
+class LcdTimeFormat(_CaseInsensitiveStrEnum):
+    """LCD clock display formats."""
+
+    TWELVE_HOUR = "12h"
+    TWENTY_FOUR_HOUR = "24h"
+
+
+class EdidPreset(StrEnum):
+    """Built-in NanoKVM Pro EDID presets."""
+
+    UHD_4K_30HZ = "E18-4K30FPS"
+    UHD_4K_39HZ = "E48-4K39FPS"
+    QHD_1440P_60HZ = "E56-2K60FPS"
+    FHD_1080P_60HZ = "E54-1080P60FPS"
+    WQUXGA_3840X2400_30HZ = "E58-4K16-10"
+    ULTRAWIDE_3440X1440_60HZ = "E63-Ultrawide"
+
+
+EdidValue = EdidPreset | str
+
+
+def _normalize_edid_value(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return EdidPreset(value)
+        except ValueError:
+            return value
+    return value
 
 
 class RefreshVirtualDeviceReq(BaseModel):
@@ -47,11 +90,21 @@ class SetLowPowerReq(BaseModel):
 
 
 class GetEdidRsp(BaseModel):
-    edid: str
+    edid: EdidValue
+
+    @field_validator("edid", mode="before")
+    @classmethod
+    def _normalize_edid(cls, value: Any) -> Any:
+        return _normalize_edid_value(value)
 
 
 class SwitchEdidReq(BaseModel):
-    edid: str
+    edid: EdidValue
+
+    @field_validator("edid", mode="before")
+    @classmethod
+    def _normalize_edid(cls, value: Any) -> Any:
+        return _normalize_edid_value(value)
 
 
 class GetCustomEdidListRsp(BaseModel):
@@ -59,9 +112,18 @@ class GetCustomEdidListRsp(BaseModel):
 
     edid_list: list[str] = Field(default_factory=list, alias="edidList")
 
+    @field_validator("edid_list", mode="before")
+    @classmethod
+    def _normalize_edid_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
 
 class DeleteEdidReq(BaseModel):
     edid: str
+
+
+class UploadEdidRsp(BaseModel):
+    file: str
 
 
 class GetHdmiCaptureRsp(BaseModel):
@@ -96,11 +158,11 @@ class GetTimeStatusRsp(BaseModel):
 
 
 class GetLcdTimeFormatRsp(BaseModel):
-    format: str
+    format: LcdTimeFormat
 
 
 class SetLcdTimeFormatReq(BaseModel):
-    format: str
+    format: LcdTimeFormat
 
 
 class GetMenuBarConfigRsp(BaseModel):
@@ -137,6 +199,11 @@ class ScanWifiRsp(BaseModel):
 
     wifi_list: list[WiFiInfo] = Field(default_factory=list, alias="wifiList")
 
+    @field_validator("wifi_list", mode="before")
+    @classmethod
+    def _normalize_wifi_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
 
 class GetStaticIPRsp(BaseModel):
     enabled: bool
@@ -154,7 +221,7 @@ class SetRateControlModeReq(BaseModel):
 
 
 class SetStreamModeReq(BaseModel):
-    mode: str
+    mode: StreamMode
 
 
 class SetStreamQualityReq(BaseModel):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,22 @@
+import aiohttp
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 import pytest
+import yarl
 
-from nanokvm.client import NanoKVMApiError, NanoKVMClient
-from nanokvm.models import ApiResponseCode
+from nanokvm.client import NanoKVMApiError, NanoKVMClient, NanoKVMNotSupportedError
+from nanokvm.models import (
+    ApiResponseCode,
+    DiskType,
+    GetMacRsp,
+    GetOLEDRsp,
+    HWVersion,
+    MouseJigglerMode,
+    OledType,
+    ShortcutKey,
+    StreamMode,
+    VirtualDevice,
+)
 
 
 async def test_get_images_success() -> None:
@@ -67,6 +80,451 @@ async def test_get_images_api_error() -> None:
 
             assert exc_info.value.code == ApiResponseCode.FAILURE
             assert "failed to list images" in exc_info.value.msg
+
+
+async def test_api_error_allows_endpoint_specific_codes() -> None:
+    """Test endpoint-specific API error codes are surfaced as API errors."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/storage/image/mount",
+                payload={"code": -6, "msg": "mount image failed", "data": None},
+            )
+
+            with pytest.raises(NanoKVMApiError) as exc_info:
+                await client.mount_image("/data/missing.iso", read_only=True)
+
+            assert exc_info.value.code == -6
+            assert "mount image failed" in exc_info.value.msg
+
+
+async def test_none_returning_endpoint_preserves_unknown_api_code() -> None:
+    """Test unknown API codes from None-returning endpoints remain API errors."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/vm/web-title",
+                payload={"code": -4, "msg": "failed to set title", "data": None},
+            )
+
+            with pytest.raises(NanoKVMApiError) as exc_info:
+                await client.set_web_title("NanoKVM")
+
+            assert exc_info.value.code == -4
+            assert "failed to set title" in exc_info.value.msg
+
+
+async def test_mount_image_sends_pro_read_only_flag() -> None:
+    """Test mount_image sends the Pro readOnly field."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/storage/image/mount",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            await client.mount_image("/data/test.img", read_only=True)
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/storage/image/mount"))
+            ]
+            assert calls[0].kwargs.get("json") == {
+                "file": "/data/test.img",
+                "cdrom": False,
+                "readOnly": True,
+            }
+
+
+async def test_get_oled_info_raises_for_pro_invalid_file_content() -> None:
+    """Test Pro OLED invalid file content follows upstream error semantics."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PRO
+
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/vm/oled",
+                payload={
+                    "code": -2,
+                    "msg": "invalid file content",
+                    "data": None,
+                },
+            )
+
+            with pytest.raises(NanoKVMApiError) as exc_info:
+                await client.get_oled_info()
+
+            assert exc_info.value.code == -2
+            assert exc_info.value.msg == "invalid file content"
+            info_url = yarl.URL("http://localhost:8888/api/vm/info")
+            assert ("GET", info_url) not in m.requests
+
+
+async def test_set_mouse_jiggler_state_noops_when_already_disabled() -> None:
+    """Test disabling mouse jiggler is idempotent."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/vm/mouse-jiggler",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {"enabled": False, "mode": "relative"},
+                },
+            )
+
+            await client.set_mouse_jiggler_state(
+                enabled=False,
+                mode=MouseJigglerMode.RELATIVE,
+            )
+
+            post_url = yarl.URL("http://localhost:8888/api/vm/mouse-jiggler/")
+            assert ("POST", post_url) not in m.requests
+
+
+async def test_update_virtual_device_ignores_success_data() -> None:
+    """Test update_virtual_device handles non-Pro success payloads."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/vm/device/virtual",
+                payload={"code": 0, "msg": "success", "data": {"on": True}},
+            )
+
+            await client.update_virtual_device(VirtualDevice.DISK)
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/vm/device/virtual"))
+            ]
+            assert calls[0].kwargs.get("json") == {"device": "disk"}
+
+
+async def test_get_virtual_device_status_handles_legacy_shape() -> None:
+    """Test virtual device status keeps legacy fields intact."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/vm/device/virtual",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {"network": True, "media": False, "disk": True},
+                },
+            )
+
+            response = await client.get_virtual_device_status()
+
+            assert response.network is True
+            assert response.media is False
+            assert response.disk is True
+            assert response.mounted_disk is None
+
+
+async def test_get_virtual_device_status_handles_pro_shape() -> None:
+    """Test Pro virtual device status exposes Pro fields without fake legacy disk."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PRO
+
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/vm/device/virtual",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {
+                        "isNetworkEnabled": True,
+                        "isMicEnabled": True,
+                        "mountedDisk": "emmc",
+                        "isSdCardExist": True,
+                        "isEmmcExist": True,
+                    },
+                },
+            )
+
+            response = await client.get_virtual_device_status()
+
+            assert response.network is True
+            assert response.mic is True
+            assert response.mounted_disk == "emmc"
+            assert response.is_sd_card_exist is True
+            assert response.is_emmc_exist is True
+            assert response.media is None
+            assert response.disk is None
+
+
+async def test_update_virtual_device_sends_pro_disk_type() -> None:
+    """Test Pro disk virtual device requests include the disk type."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PRO
+
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/vm/device/virtual",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            await client.update_virtual_device(
+                VirtualDevice.DISK,
+                disk_type=DiskType.EMMC,
+            )
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/vm/device/virtual"))
+            ]
+            assert calls[0].kwargs.get("json") == {
+                "device": "disk",
+                "type": "emmc",
+            }
+
+
+async def test_set_led_strip_partial_preserves_current_config() -> None:
+    """Test partial LED updates post a complete Pro LED configuration."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PRO
+
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/vm/ledstrip/get",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {
+                        "on": True,
+                        "hor": 8,
+                        "ver": 6,
+                        "brightness": 25,
+                    },
+                },
+            )
+            m.post(
+                "http://localhost:8888/api/vm/ledstrip/set",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            await client.set_led_strip(brightness=50)
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/vm/ledstrip/set"))
+            ]
+            assert calls[0].kwargs.get("json") == {
+                "on": True,
+                "hor": 8,
+                "ver": 6,
+                "brightness": 50,
+            }
+
+
+async def test_get_wol_macs_returns_empty_list_for_missing_file() -> None:
+    """Test WOL getter normalizes the empty-file device state."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/network/wol/mac",
+                payload={"code": -2, "msg": "open file error", "data": None},
+            )
+
+            response = await client.get_wol_macs()
+
+            assert response.macs == []
+
+
+def test_model_normalizations_for_wol_and_oled() -> None:
+    """Test model-only compatibility normalizers."""
+    assert GetMacRsp(macs=["", "AA:BB:CC:DD:EE:FF", "   "]).macs == [
+        "AA:BB:CC:DD:EE:FF"
+    ]
+    assert GetOLEDRsp(exist=True, type="desk", sleep=0).type == OledType.DESK
+
+
+async def test_connect_wifi_no_auth_sends_ap_header() -> None:
+    """Test AP-mode Wi-Fi connection sends setup credentials without auth cookie."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/network/wifi",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            await client.connect_wifi_no_auth(
+                "NanoKVM-Setup",
+                ap_password="setup-secret",
+            )
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/network/wifi"))
+            ]
+            assert calls[0].kwargs.get("json") == {
+                "ssid": "NanoKVM-Setup",
+                "password": "",
+            }
+            assert calls[0].kwargs.get("cookies") == {}
+            assert calls[0].kwargs.get("headers", {})["X-AP-Key"] == "setup-secret"
+
+
+async def test_upload_script_uses_multipart_form(tmp_path) -> None:
+    """Test script upload uses the shared multipart helper."""
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/sh\ntrue\n")
+
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/vm/script/upload",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {"file": "test.sh"},
+                },
+            )
+
+            response = await client.upload_script(script)
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/vm/script/upload"))
+            ]
+            assert isinstance(calls[0].kwargs.get("data"), aiohttp.FormData)
+            assert response.file == "test.sh"
+
+
+async def test_shortcut_methods_send_expected_payloads() -> None:
+    """Test custom shortcut client helpers use the expected endpoints."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/hid/shortcut",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+            m.delete(
+                "http://localhost:8888/api/hid/shortcut",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+            m.post(
+                "http://localhost:8888/api/hid/shortcut/leader-key",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            key = ShortcutKey(code="ControlLeft", label="Ctrl")
+            await client.add_shortcut([key])
+            await client.delete_shortcut("shortcut-1")
+            await client.set_leader_key("ControlLeft")
+
+            shortcut_calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/hid/shortcut"))
+            ]
+            delete_calls = m.requests[
+                ("DELETE", yarl.URL("http://localhost:8888/api/hid/shortcut"))
+            ]
+            leader_calls = m.requests[
+                (
+                    "POST",
+                    yarl.URL("http://localhost:8888/api/hid/shortcut/leader-key"),
+                )
+            ]
+            assert shortcut_calls[0].kwargs.get("json") == {
+                "keys": [{"code": "ControlLeft", "label": "Ctrl"}]
+            }
+            assert delete_calls[0].kwargs.get("json") == {"id": "shortcut-1"}
+            assert leader_calls[0].kwargs.get("json") == {"key": "ControlLeft"}
+
+
+async def test_tailscale_login_returns_url() -> None:
+    """Test Tailscale login returns the upstream login URL payload."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/extensions/tailscale/login",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {"url": "https://login.tailscale.com/a/test"},
+                },
+            )
+
+            response = await client.tailscale_login()
+
+            assert response.url == "https://login.tailscale.com/a/test"
+
+
+async def test_set_stream_mode_accepts_existing_string_values() -> None:
+    """Test set_stream_mode remains source-compatible with valid strings."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PRO
+
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/stream/mode",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            await client.set_stream_mode(StreamMode.H264_DIRECT.value)
+
+            calls = m.requests[
+                ("POST", yarl.URL("http://localhost:8888/api/stream/mode"))
+            ]
+            assert calls[0].kwargs.get("json") == {"mode": "h264-direct"}
+
+
+async def test_enable_swap_404_is_not_supported() -> None:
+    """Test legacy swap enable 404 becomes NanoKVMNotSupportedError."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PCIE
+
+        with aioresponses() as m:
+            m.post("http://localhost:8888/api/vm/swap/enable", status=404)
+
+            with pytest.raises(NanoKVMNotSupportedError) as exc_info:
+                await client.enable_swap()
+
+            assert "enable_swap is unavailable" in str(exc_info.value)
+
+
+async def test_disable_swap_404_is_not_supported() -> None:
+    """Test legacy swap disable 404 becomes NanoKVMNotSupportedError."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        client._hw_version = HWVersion.PCIE
+
+        with aioresponses() as m:
+            m.post("http://localhost:8888/api/vm/swap/disable", status=404)
+
+            with pytest.raises(NanoKVMNotSupportedError) as exc_info:
+                await client.disable_swap()
+
+            assert "disable_swap is unavailable" in str(exc_info.value)
 
 
 async def test_client_context_manager() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import aiohttp
 from aiohttp import ClientSession
 from aioresponses import aioresponses
@@ -384,7 +386,7 @@ async def test_connect_wifi_no_auth_sends_ap_header() -> None:
             assert calls[0].kwargs.get("headers", {})["X-AP-Key"] == "setup-secret"
 
 
-async def test_upload_script_uses_multipart_form(tmp_path) -> None:
+async def test_upload_script_uses_multipart_form(tmp_path: Path) -> None:
     """Test script upload uses the shared multipart helper."""
     script = tmp_path / "test.sh"
     script.write_text("#!/bin/sh\ntrue\n")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -212,8 +212,8 @@ async def test_update_virtual_device_ignores_success_data() -> None:
             assert calls[0].kwargs.get("json") == {"device": "disk"}
 
 
-async def test_get_virtual_device_status_handles_legacy_shape() -> None:
-    """Test virtual device status keeps legacy fields intact."""
+async def test_get_virtual_device_status_handles_non_pro_shape() -> None:
+    """Test virtual device status keeps non-Pro fields intact."""
     async with NanoKVMClient(
         "http://localhost:8888/api/", token="test-token"
     ) as client:
@@ -236,7 +236,7 @@ async def test_get_virtual_device_status_handles_legacy_shape() -> None:
 
 
 async def test_get_virtual_device_status_handles_pro_shape() -> None:
-    """Test Pro virtual device status exposes Pro fields without fake legacy disk."""
+    """Test Pro virtual device status exposes Pro fields without fake non-Pro disk."""
     async with NanoKVMClient(
         "http://localhost:8888/api/", token="test-token"
     ) as client:
@@ -498,7 +498,7 @@ async def test_set_stream_mode_accepts_existing_string_values() -> None:
 
 
 async def test_enable_swap_404_is_not_supported() -> None:
-    """Test legacy swap enable 404 becomes NanoKVMNotSupportedError."""
+    """Test non-Pro swap enable 404 becomes NanoKVMNotSupportedError."""
     async with NanoKVMClient(
         "http://localhost:8888/api/", token="test-token"
     ) as client:
@@ -510,11 +510,11 @@ async def test_enable_swap_404_is_not_supported() -> None:
             with pytest.raises(NanoKVMNotSupportedError) as exc_info:
                 await client.enable_swap()
 
-            assert "enable_swap is unavailable" in str(exc_info.value)
+            assert "enable_swap is unavailable on this non-Pro" in str(exc_info.value)
 
 
 async def test_disable_swap_404_is_not_supported() -> None:
-    """Test legacy swap disable 404 becomes NanoKVMNotSupportedError."""
+    """Test non-Pro swap disable 404 becomes NanoKVMNotSupportedError."""
     async with NanoKVMClient(
         "http://localhost:8888/api/", token="test-token"
     ) as client:
@@ -526,7 +526,7 @@ async def test_disable_swap_404_is_not_supported() -> None:
             with pytest.raises(NanoKVMNotSupportedError) as exc_info:
                 await client.disable_swap()
 
-            assert "disable_swap is unavailable" in str(exc_info.value)
+            assert "disable_swap is unavailable on this non-Pro" in str(exc_info.value)
 
 
 async def test_client_context_manager() -> None:


### PR DESCRIPTION
## Summary
This expands the client with additional NanoKVM and NanoKVM-Pro API coverage while aligning shared models with the upstream Sipeed API shapes.

The main goal is to make the Pro support added in the previous work more complete and safer without pretending to cover every upstream endpoint yet.

## What Changed
- Added client helpers for script management, HID shortcuts, Wi-Fi AP setup, Wake-on-LAN MAC management, Pro EDID controls, Pro HDMI capture/passthrough, Pro low-power mode, Pro LED strip config, Pro time settings, Pro menu bar config, Pro stream settings, and Pro extension controls.
- Moved virtual-device status handling into the shared model layer because NanoKVM and NanoKVM-Pro expose the same route with different payload shapes.
- Normalized upstream response edge cases, including empty list payloads, missing WOL cache files, blank WOL entries, Pro Wi-Fi nested details, OLED type casing, custom EDID lists, and Pro mounted disk fields.
- Aligned OLED error behavior with upstream NanoKVM-Pro: invalid OLED hardware/version content now raises the API error instead of fabricating a DESK/ATX type.
- Preserved compatibility for existing successful legacy payloads while exposing Pro-only fields where upstream provides them.
- Added tests for the new methods, payload shapes, response normalizers, and strict upstream error behavior.

## Design Notes
- Shared API models remain in `nanokvm.models.common`; Pro-only request/response models remain in `nanokvm.models.pro`.
- Pro virtual-device status uses `mounted_disk`, `is_sd_card_exist`, and `is_emmc_exist` rather than mapping Pro disk state onto the legacy `disk`/`media` fields.
- LED strip updates send a full configuration when callers provide partial values, avoiding accidental Go zero-value behavior on the device.
- This PR intentionally focuses on the client/model coverage already represented here and does not attempt full upstream parity.
