### PR TITLE
Fix NanoKVM mouse, streaming, and download compatibility

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -188,7 +188,8 @@ class NanoKVMNotSupportedError(NanoKVMError):
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
 
 _VERSION_RE = re.compile(r"^v?(\d+(?:\.\d+)*)$")
-_BINARY_MOUSE_MIN_VERSION = "2.3.2"
+_BINARY_MOUSE_MIN_NON_PRO_VERSION = "2.3.2"
+_BINARY_MOUSE_MIN_PRO_VERSION = "1.2.6"
 
 
 def _parse_version(version: str) -> tuple[int, ...] | None:
@@ -1842,11 +1843,11 @@ class NanoKVMClient:
     async def _uses_binary_mouse_protocol(self) -> bool:
         """Select the mouse wire format supported by the connected device.
 
-        NanoKVM changed mouse events from JSON to raw HID reports in 2.3.2.
-        The Pro firmware uses the raw HID protocol on its separate version
-        line. This has to be a dispatcher rather than a version requirement:
-        application versions before 2.3.2 still support mouse control through
-        the legacy JSON format.
+        NanoKVM changed mouse events from JSON to raw HID reports in 2.3.2;
+        the Pro firmware made the same change in application version 1.2.6.
+        This has to be a dispatcher rather than a version requirement:
+        earlier application versions still support mouse control through the
+        legacy JSON format.
         """
         if self._hw_version is None:
             if self._token is None:
@@ -1856,16 +1857,18 @@ class NanoKVMClient:
                 return True
             await self.detect_hardware()
 
-        if self._hw_version == HWVersion.PRO:
-            return True
-
         if self._application_version is None:
             if self._token is None:
                 return True
             await self.detect_versions()
 
+        minimum_version = (
+            _BINARY_MOUSE_MIN_PRO_VERSION
+            if self._hw_version == HWVersion.PRO
+            else _BINARY_MOUSE_MIN_NON_PRO_VERSION
+        )
         return self._application_version is None or _version_at_least(
-            self._application_version, _BINARY_MOUSE_MIN_VERSION
+            self._application_version, minimum_version
         )
 
     @staticmethod

--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -319,6 +319,9 @@ class NanoKVMClient:
         self._token = token
         self._request_timeout = request_timeout
         self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._mouse_buttons = 0
+        self._mouse_mode = "relative"
+        self._mouse_abs_position = (0, 0)
         self._verify_ssl = verify_ssl
         self._ssl_ca_cert = ssl_ca_cert
         self._ssl_fingerprint = ssl_fingerprint
@@ -426,6 +429,7 @@ class NanoKVMClient:
         path: str,
         *,
         authenticate: bool = True,
+        timeout: aiohttp.ClientTimeout | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[ClientResponse]:
         """Make an API request."""
@@ -448,7 +452,7 @@ class NanoKVMClient:
             self.url / path.lstrip("/"),
             headers=request_headers,
             cookies=cookies,
-            timeout=aiohttp.ClientTimeout(total=self._request_timeout),
+            timeout=timeout or aiohttp.ClientTimeout(total=self._request_timeout),
             raise_for_status=True,
             ssl=self._ssl_config,
             **kwargs,
@@ -484,7 +488,7 @@ class NanoKVMClient:
         **kwargs: Any,
     ) -> T | None:
         """Make API request and parse JSON response."""
-        _LOGGER.debug("Making API request: %s %s (%s)", method, path, data)
+        _LOGGER.debug("Making API request: %s %s", method, path)
 
         async with self._request(
             method,
@@ -498,7 +502,6 @@ class NanoKVMClient:
         ) as response:
             try:
                 raw_response = await response.json(content_type=None)
-                _LOGGER.debug("Raw JSON response data: %s", raw_response)
             except (json.JSONDecodeError, ValidationError) as err:
                 raise NanoKVMInvalidResponseError(
                     f"Invalid JSON response received: {err}"
@@ -569,7 +572,9 @@ class NanoKVMClient:
                 f"Invalid JSON response received: {err}"
             ) from err
 
-        _LOGGER.debug("Got API response: %s", api_response)
+        _LOGGER.debug(
+            "Got API response: code=%s msg=%s", api_response.code, api_response.msg
+        )
 
         if api_response.code != ApiResponseCode.SUCCESS.value:
             raise NanoKVMApiError(
@@ -1627,7 +1632,11 @@ class NanoKVMClient:
 
     async def mjpeg_stream(self) -> AsyncIterator[Image.Image]:
         """Stream MJPEG frames."""
-        async with self._request(hdrs.METH_GET, "/stream/mjpeg") as response:
+        async with self._request(
+            hdrs.METH_GET,
+            "/stream/mjpeg",
+            timeout=aiohttp.ClientTimeout(total=None, connect=self._request_timeout),
+        ) as response:
             reader = MultipartReader.from_response(response)
             loop = asyncio.get_running_loop()
 
@@ -1829,34 +1838,45 @@ class NanoKVMClient:
             )
         return self._ws
 
-    async def _send_mouse_event(
-        self, event_type: int, button_state: int, x: float, y: float
-    ) -> None:
-        """
-        Send a mouse event via WebSocket.
+    @staticmethod
+    def _clamp(value: int, minimum: int, maximum: int) -> int:
+        return max(minimum, min(maximum, value))
 
-        Args:
-            event_type: 0=mouse_up, 1=mouse_down, 2=move_abs, 3=move_rel, 4=scroll
-            button_state: Button state (0=no buttons, 1=left, 2=right, 4=middle)
-            x: X coordinate (0.0-1.0 for abs/rel/scroll) or 0.0 for button events
-            y: Y coordinate (0.0-1.0 for abs/rel/scroll) or 0.0 for button events
-        """
+    @classmethod
+    def _relative_value(cls, value: float) -> int:
+        return cls._clamp(round(value * 127), -127, 127)
+
+    @classmethod
+    def _absolute_value(cls, value: float) -> int:
+        return cls._clamp(round(max(0.0, min(1.0, value)) * 32767), 0, 32767)
+
+    def _absolute_report(self, wheel: int = 0) -> bytes:
+        x, y = self._mouse_abs_position
+        return bytes(
+            (
+                self._mouse_buttons,
+                x & 0xFF,
+                (x >> 8) & 0xFF,
+                y & 0xFF,
+                (y >> 8) & 0xFF,
+                self._clamp(wheel, -127, 127) & 0xFF,
+            )
+        )
+
+    def _relative_report(self, dx: int = 0, dy: int = 0, wheel: int = 0) -> bytes:
+        return bytes(
+            (
+                self._mouse_buttons,
+                self._clamp(dx, -127, 127) & 0xFF,
+                self._clamp(dy, -127, 127) & 0xFF,
+                self._clamp(wheel, -127, 127) & 0xFF,
+            )
+        )
+
+    async def _send_mouse_report(self, report: bytes) -> None:
+        """Send a binary NanoKVM mouse event and HID report."""
         ws = await self._get_ws()
-
-        # Scale coordinates for absolute/relative movements and scroll
-        if event_type in (2, 3, 4):  # move_abs, move_rel, or scroll
-            x_val = int(x * 32768)
-            y_val = int(y * 32768)
-        else:
-            x_val = int(x)
-            y_val = int(y)
-
-        # Message format: [2, event_type, button_state, x_val, y_val]
-        # where 2 indicates mouse event
-        message = [2, event_type, button_state, x_val, y_val]
-
-        _LOGGER.debug("Sending mouse event: %s", message)
-        await ws.send_json(message)
+        await ws.send_bytes(bytes((2,)) + report)
 
     async def mouse_move_abs(self, x: float, y: float) -> None:
         """
@@ -1866,7 +1886,9 @@ class NanoKVMClient:
             x: X coordinate (0.0 to 1.0, left to right)
             y: Y coordinate (0.0 to 1.0, top to bottom)
         """
-        await self._send_mouse_event(2, 0, x, y)
+        self._mouse_mode = "absolute"
+        self._mouse_abs_position = (self._absolute_value(x), self._absolute_value(y))
+        await self._send_mouse_report(self._absolute_report())
 
     async def mouse_move_rel(self, dx: float, dy: float) -> None:
         """
@@ -1876,7 +1898,10 @@ class NanoKVMClient:
             dx: Horizontal movement (-1.0 to 1.0)
             dy: Vertical movement (-1.0 to 1.0)
         """
-        await self._send_mouse_event(3, 0, dx, dy)
+        self._mouse_mode = "relative"
+        await self._send_mouse_report(
+            self._relative_report(self._relative_value(dx), self._relative_value(dy))
+        )
 
     async def mouse_down(self, button: MouseButton = MouseButton.LEFT) -> None:
         """
@@ -1886,15 +1911,25 @@ class NanoKVMClient:
             button: Mouse button to press (MouseButton.LEFT, MouseButton.RIGHT,
                 MouseButton.MIDDLE)
         """
-        await self._send_mouse_event(1, int(button), 0.0, 0.0)
+        self._mouse_buttons |= int(button)
+        if self._mouse_mode == "absolute":
+            report = self._absolute_report()
+        else:
+            report = self._relative_report()
+        await self._send_mouse_report(report)
 
     async def mouse_up(self) -> None:
         """
         Release a mouse button.
 
-        Note: Mouse up event always uses button_state=0 per the NanoKVM protocol.
+        The report releases all currently held buttons.
         """
-        await self._send_mouse_event(0, 0, 0.0, 0.0)
+        self._mouse_buttons = 0
+        if self._mouse_mode == "absolute":
+            report = self._absolute_report()
+        else:
+            report = self._relative_report()
+        await self._send_mouse_report(report)
 
     async def mouse_click(
         self,
@@ -1934,4 +1969,10 @@ class NanoKVMClient:
             dx: Horizontal scroll amount (-1.0 to 1.0)
             dy: Vertical scroll amount (-1.0 to 1.0) # positive=up, negative=down)
         """
-        await self._send_mouse_event(4, 0, dx, dy)
+        del dx  # NanoKVM's boot mouse report has a single vertical wheel byte.
+        wheel = self._relative_value(dy)
+        if self._mouse_mode == "absolute":
+            report = self._absolute_report(wheel)
+        else:
+            report = self._relative_report(wheel=wheel)
+        await self._send_mouse_report(report)

--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -188,6 +188,7 @@ class NanoKVMNotSupportedError(NanoKVMError):
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
 
 _VERSION_RE = re.compile(r"^v?(\d+(?:\.\d+)*)$")
+_BINARY_MOUSE_MIN_VERSION = "2.3.2"
 
 
 def _parse_version(version: str) -> tuple[int, ...] | None:
@@ -1838,6 +1839,35 @@ class NanoKVMClient:
             )
         return self._ws
 
+    async def _uses_binary_mouse_protocol(self) -> bool:
+        """Select the mouse wire format supported by the connected device.
+
+        NanoKVM changed mouse events from JSON to raw HID reports in 2.3.2.
+        The Pro firmware uses the raw HID protocol on its separate version
+        line. This has to be a dispatcher rather than a version requirement:
+        application versions before 2.3.2 still support mouse control through
+        the legacy JSON format.
+        """
+        if self._hw_version is None:
+            if self._token is None:
+                # The WebSocket will report the authentication error below.
+                # Keep the current protocol as the safe default when version
+                # detection is not possible.
+                return True
+            await self.detect_hardware()
+
+        if self._hw_version == HWVersion.PRO:
+            return True
+
+        if self._application_version is None:
+            if self._token is None:
+                return True
+            await self.detect_versions()
+
+        return self._application_version is None or _version_at_least(
+            self._application_version, _BINARY_MOUSE_MIN_VERSION
+        )
+
     @staticmethod
     def _clamp(value: int, minimum: int, maximum: int) -> int:
         return max(minimum, min(maximum, value))
@@ -1878,6 +1908,23 @@ class NanoKVMClient:
         ws = await self._get_ws()
         await ws.send_bytes(bytes((2,)) + report)
 
+    async def _send_legacy_mouse_event(
+        self, event_type: int, button_state: int, x: float, y: float
+    ) -> None:
+        """Send a mouse event using the pre-2.3.2 JSON wire format."""
+        ws = await self._get_ws()
+
+        if event_type in (2, 3, 4):
+            x_value = int(x * 32768)
+            y_value = int(y * 32768)
+        else:
+            x_value = int(x)
+            y_value = int(y)
+
+        message = [2, event_type, button_state, x_value, y_value]
+        _LOGGER.debug("Sending legacy mouse event: %s", message)
+        await ws.send_json(message)
+
     async def mouse_move_abs(self, x: float, y: float) -> None:
         """
         Move mouse to absolute position.
@@ -1886,6 +1933,10 @@ class NanoKVMClient:
             x: X coordinate (0.0 to 1.0, left to right)
             y: Y coordinate (0.0 to 1.0, top to bottom)
         """
+        if not await self._uses_binary_mouse_protocol():
+            await self._send_legacy_mouse_event(2, 0, x, y)
+            return
+
         self._mouse_mode = "absolute"
         self._mouse_abs_position = (self._absolute_value(x), self._absolute_value(y))
         await self._send_mouse_report(self._absolute_report())
@@ -1898,6 +1949,10 @@ class NanoKVMClient:
             dx: Horizontal movement (-1.0 to 1.0)
             dy: Vertical movement (-1.0 to 1.0)
         """
+        if not await self._uses_binary_mouse_protocol():
+            await self._send_legacy_mouse_event(3, 0, dx, dy)
+            return
+
         self._mouse_mode = "relative"
         await self._send_mouse_report(
             self._relative_report(self._relative_value(dx), self._relative_value(dy))
@@ -1911,6 +1966,10 @@ class NanoKVMClient:
             button: Mouse button to press (MouseButton.LEFT, MouseButton.RIGHT,
                 MouseButton.MIDDLE)
         """
+        if not await self._uses_binary_mouse_protocol():
+            await self._send_legacy_mouse_event(1, int(button), 0.0, 0.0)
+            return
+
         self._mouse_buttons |= int(button)
         if self._mouse_mode == "absolute":
             report = self._absolute_report()
@@ -1924,6 +1983,10 @@ class NanoKVMClient:
 
         The report releases all currently held buttons.
         """
+        if not await self._uses_binary_mouse_protocol():
+            await self._send_legacy_mouse_event(0, 0, 0.0, 0.0)
+            return
+
         self._mouse_buttons = 0
         if self._mouse_mode == "absolute":
             report = self._absolute_report()
@@ -1969,6 +2032,10 @@ class NanoKVMClient:
             dx: Horizontal scroll amount (-1.0 to 1.0)
             dy: Vertical scroll amount (-1.0 to 1.0) # positive=up, negative=down)
         """
+        if not await self._uses_binary_mouse_protocol():
+            await self._send_legacy_mouse_event(4, 0, dx, dy)
+            return
+
         del dx  # NanoKVM's boot mouse report has a single vertical wheel byte.
         wheel = self._relative_value(dy)
         if self._mouse_mode == "absolute":

--- a/nanokvm/models/common.py
+++ b/nanokvm/models/common.py
@@ -76,6 +76,9 @@ class DownloadStatus(StrEnum):
 
     IDLE = "idle"
     IN_PROGRESS = "in_progress"
+    SUCCESS = "success"
+    FAILED = "failed"
+    CHECKSUM_FAILED = "checksum_failed"
 
 
 class HWVersion(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ testing = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-timeout",
-    "aioresponses",
+    "aioresponses-ng>=0.8.2",
 ]
 
 [tool.setuptools-git-versioning]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,11 @@
+import asyncio
+import io
 from pathlib import Path
 
 import aiohttp
-from aiohttp import ClientSession
+from aiohttp import ClientSession, web
 from aioresponses import aioresponses
+from PIL import Image
 import pytest
 import yarl
 
@@ -17,12 +20,14 @@ from nanokvm.models import (
     ApiResponseCode,
     DiskType,
     DNSMode,
+    DownloadStatus,
     GetMacRsp,
     GetOLEDRsp,
     HWVersion,
     MouseJigglerMode,
     OledType,
     ShortcutKey,
+    StatusImageRsp,
     StreamMode,
     VirtualDevice,
 )
@@ -59,6 +64,17 @@ def test_version_parser() -> None:
     assert _version_at_least("2.4", "2.4.0")
     assert not _version_at_least("2.4.0", "2.4.1")
     assert _version_at_least("dev", "2.4.1")
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["success", "failed", "checksum_failed"],
+)
+def test_download_status_accepts_terminal_states(status: str) -> None:
+    """Download status responses include terminal success and failure states."""
+    response = StatusImageRsp(status=status, file="image.iso", percentage="")
+
+    assert response.status is DownloadStatus(status)
 
 
 async def test_get_images_success() -> None:
@@ -104,6 +120,56 @@ async def test_get_images_empty() -> None:
 
             assert response is not None
             assert len(response.files) == 0
+
+
+async def test_mjpeg_stream_allows_frames_after_request_timeout() -> None:
+    """An MJPEG stream remains open beyond the normal request timeout."""
+    image_buffer = io.BytesIO()
+    Image.new("RGB", (2, 2)).save(image_buffer, format="JPEG")
+    image_data = image_buffer.getvalue()
+
+    async def stream_handler(
+        request: web.Request,
+    ) -> web.StreamResponse:
+        response = web.StreamResponse(
+            headers={"Content-Type": "multipart/x-mixed-replace; boundary=frame"}
+        )
+        await response.prepare(request)
+        for _ in range(2):
+            await response.write(
+                b"--frame\r\n"
+                b"Content-Type: image/jpeg\r\n"
+                + f"Content-Length: {len(image_data)}\r\n\r\n".encode()
+                + image_data
+                + b"\r\n"
+            )
+            await asyncio.sleep(0.55)
+        await response.write(b"--frame--\r\n")
+        await response.write_eof()
+        return response
+
+    application = web.Application()
+    application.router.add_get("/api/stream/mjpeg", stream_handler)
+    runner = web.AppRunner(application)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    server_sockets = getattr(site._server, "sockets", None)
+    assert server_sockets
+    port = server_sockets[0].getsockname()[1]
+
+    frames = []
+    try:
+        async with NanoKVMClient(
+            f"http://127.0.0.1:{port}/api/", token="test-token", request_timeout=1
+        ) as client:
+            async with asyncio.timeout(3):
+                async for frame in client.mjpeg_stream():
+                    frames.append(frame)
+    finally:
+        await runner.cleanup()
+
+    assert len(frames) == 2
 
 
 async def test_get_images_api_error() -> None:

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -12,7 +12,7 @@ from nanokvm.models import MouseButton
 
 @pytest.fixture
 async def client_with_mock_ws() -> AsyncGenerator[tuple[NanoKVMClient, AsyncMock], Any]:
-    """Fixture that provides a client with mocked WebSocket."""
+    """Fixture that provides a client with a mocked WebSocket."""
     mock_ws = AsyncMock()
     mock_ws.closed = False
 
@@ -25,155 +25,74 @@ async def client_with_mock_ws() -> AsyncGenerator[tuple[NanoKVMClient, AsyncMock
             yield client, mock_ws
 
 
-async def test_mouse_move_abs(
+def _sent_reports(mock_ws: AsyncMock) -> list[bytes]:
+    return [call.args[0] for call in mock_ws.send_bytes.call_args_list]
+
+
+async def test_mouse_move_abs_sends_hid_report(
     client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
 ) -> None:
-    """Test absolute mouse movement."""
+    """Absolute movement uses the binary six-byte HID report."""
     client, mock_ws = client_with_mock_ws
 
     await client.mouse_move_abs(0.5, 0.5)
 
-    # Verify the WebSocket send was called with correct parameters
-    mock_ws.send_json.assert_called_once()
-    message = mock_ws.send_json.call_args[0][0]
-    # Message format: [2, event_type, button_state, x_val, y_val]
-    assert message[0] == 2  # mouse event indicator
-    assert message[1] == 2  # move_abs
-    assert message[2] == 0  # button state
-    # 0.5 * 32768 = 16384
-    assert message[3] == 16384
-    assert message[4] == 16384
+    assert _sent_reports(mock_ws) == [bytes([2, 0, 0, 64, 0, 64, 0])]
+    mock_ws.send_json.assert_not_called()
 
 
-async def test_mouse_move_rel(
+async def test_mouse_move_rel_sends_signed_hid_report(
     client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
 ) -> None:
-    """Test relative mouse movement."""
+    """Relative movement is clamped and encoded as signed HID bytes."""
     client, mock_ws = client_with_mock_ws
 
     await client.mouse_move_rel(0.1, -0.1)
 
-    # Verify the WebSocket send was called with correct parameters
-    mock_ws.send_json.assert_called_once()
-    message = mock_ws.send_json.call_args[0][0]
-    # Message format: [2, event_type, button_state, x_val, y_val]
-    assert message[0] == 2  # mouse event indicator
-    assert message[1] == 3  # move_rel
-    assert message[2] == 0  # button state
-    # 0.1 * 32768 = 3276.8 -> 3276
-    assert message[3] == 3276
-    # -0.1 * 32768 = -3276.8 -> -3276
-    assert message[4] == -3276
+    assert _sent_reports(mock_ws) == [bytes([2, 0, 13, 243, 0])]
 
 
-async def test_mouse_down(client_with_mock_ws: tuple[NanoKVMClient, AsyncMock]) -> None:
-    """Test mouse button down."""
+async def test_mouse_buttons_preserve_hid_state(
+    client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Button reports use a bitmask and release all buttons on mouse_up."""
     client, mock_ws = client_with_mock_ws
 
     await client.mouse_down(MouseButton.LEFT)
-
-    # Verify the WebSocket send was called with correct parameters
-    mock_ws.send_json.assert_called_once()
-    message = mock_ws.send_json.call_args[0][0]
-    # Message format: [2, event_type, button_state, x_val, y_val]
-    assert message[0] == 2  # mouse event indicator
-    assert message[1] == 1  # mouse_down
-    assert message[2] == 1  # left button
-    assert message[3] == 0
-    assert message[4] == 0
-
-
-async def test_mouse_up(client_with_mock_ws: tuple[NanoKVMClient, AsyncMock]) -> None:
-    """Test mouse button up."""
-    client, mock_ws = client_with_mock_ws
-
+    await client.mouse_down(MouseButton.RIGHT)
     await client.mouse_up()
 
-    # Verify the WebSocket send was called with correct parameters
-    mock_ws.send_json.assert_called_once()
-    message = mock_ws.send_json.call_args[0][0]
-    # Message format: [2, event_type, button_state, x_val, y_val]
-    assert message[0] == 2  # mouse event indicator
-    assert message[1] == 0  # mouse_up
-    assert message[2] == 0  # button state (always 0 for mouse_up)
-    assert message[3] == 0
-    assert message[4] == 0
+    assert _sent_reports(mock_ws) == [
+        bytes([2, 1, 0, 0, 0]),
+        bytes([2, 3, 0, 0, 0]),
+        bytes([2, 0, 0, 0, 0]),
+    ]
 
 
-async def test_mouse_click_without_position(
+async def test_mouse_click_with_absolute_position(
     client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
 ) -> None:
-    """Test mouse click at current position."""
-    client, mock_ws = client_with_mock_ws
-
-    await client.mouse_click(MouseButton.LEFT)
-
-    # Should send two events: down and up
-    assert mock_ws.send_json.call_count == 2
-
-    # First call should be mouse_down
-    first_message = mock_ws.send_json.call_args_list[0][0][0]
-    assert first_message[0] == 2  # mouse event indicator
-    assert first_message[1] == 1  # mouse_down
-    assert first_message[2] == 1  # left button
-
-    # Second call should be mouse_up
-    second_message = mock_ws.send_json.call_args_list[1][0][0]
-    assert second_message[0] == 2  # mouse event indicator
-    assert second_message[1] == 0  # mouse_up
-    assert second_message[2] == 0  # button state (always 0 for mouse_up)
-
-
-async def test_mouse_click_with_position(
-    client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
-) -> None:
-    """Test mouse click at specific position."""
+    """An absolute click preserves its position in button reports."""
     client, mock_ws = client_with_mock_ws
 
     await client.mouse_click(MouseButton.MIDDLE, 0.25, 0.75)
 
-    # Should send three events: move_abs, down, and up
-    assert mock_ws.send_json.call_count == 3
-
-    # First call should be move_abs
-    first_message = mock_ws.send_json.call_args_list[0][0][0]
-    assert first_message[0] == 2  # mouse event indicator
-    assert first_message[1] == 2  # move_abs
-    assert first_message[3] == int(0.25 * 32768)
-    assert first_message[4] == int(0.75 * 32768)
-
-    # Second call should be mouse_down
-    second_message = mock_ws.send_json.call_args_list[1][0][0]
-    assert second_message[0] == 2  # mouse event indicator
-    assert second_message[1] == 1  # mouse_down
-    assert second_message[2] == 4  # middle button
-
-    # Third call should be mouse_up
-    third_message = mock_ws.send_json.call_args_list[2][0][0]
-    assert third_message[0] == 2  # mouse event indicator
-    assert third_message[1] == 0  # mouse_up
-    assert third_message[2] == 0  # button state (always 0 for mouse_up)
+    assert _sent_reports(mock_ws) == [
+        bytes([2, 0, 0, 32, 255, 95, 0]),
+        bytes([2, 4, 0, 32, 255, 95, 0]),
+        bytes([2, 0, 0, 32, 255, 95, 0]),
+    ]
 
 
-async def test_mouse_scroll(
+async def test_mouse_scroll_encodes_vertical_wheel(
     client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
 ) -> None:
-    """Test mouse scroll."""
+    """Scrolling uses the wheel byte of the relative HID report."""
     client, mock_ws = client_with_mock_ws
 
     await client.mouse_scroll(0.1, -0.2)
 
-    # Verify the WebSocket send was called with correct parameters
-    mock_ws.send_json.assert_called_once()
-    message = mock_ws.send_json.call_args[0][0]
-    # Message format: [2, event_type, button_state, x_val, y_val]
-    assert message[0] == 2  # mouse event indicator
-    assert message[1] == 4  # scroll
-    assert message[2] == 0  # button state
-    # 0.1 * 32768 = 3276.8 -> 3276
-    assert message[3] == 3276
-    # -0.2 * 32768 = -6553.6 -> -6553
-    assert message[4] == -6553
+    assert _sent_reports(mock_ws) == [bytes([2, 0, 0, 0, 231])]
 
 
 async def test_context_manager_cleanup() -> None:
@@ -187,13 +106,10 @@ async def test_context_manager_cleanup() -> None:
         async with NanoKVMClient(
             "http://localhost:8888/api/", token="test-token"
         ) as client:
-            # Trigger WebSocket creation by making a call
             await client.mouse_move_abs(0.0, 0.0)
-            # Verify WebSocket was created
             assert client._ws is not None
             assert client._session is not None
 
-        # After exiting context, resources should be cleaned up
         mock_ws.close.assert_called_once()
         assert client._ws is None
         assert client._session is None
@@ -205,17 +121,13 @@ async def test_button_mapping(
     """Test different button types."""
     client, mock_ws = client_with_mock_ws
 
-    # Test left button
     await client.mouse_down(MouseButton.LEFT)
-    message = mock_ws.send_json.call_args[0][0]
-    assert message[2] == MouseButton.LEFT
-
-    # Test right button
+    await client.mouse_up()
     await client.mouse_down(MouseButton.RIGHT)
-    message = mock_ws.send_json.call_args[0][0]
-    assert message[2] == MouseButton.RIGHT
-
-    # Test middle button
+    await client.mouse_up()
     await client.mouse_down(MouseButton.MIDDLE)
-    message = mock_ws.send_json.call_args[0][0]
-    assert message[2] == MouseButton.MIDDLE
+
+    reports = _sent_reports(mock_ws)
+    assert reports[0][1] == MouseButton.LEFT
+    assert reports[2][1] == MouseButton.RIGHT
+    assert reports[4][1] == MouseButton.MIDDLE

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from nanokvm.client import NanoKVMClient
-from nanokvm.models import MouseButton
+from nanokvm.models import HWVersion, MouseButton
 
 
 @pytest.fixture
@@ -22,11 +22,36 @@ async def client_with_mock_ws() -> AsyncGenerator[tuple[NanoKVMClient, AsyncMock
         async with NanoKVMClient(
             "http://localhost:8888/api/", token="test-token"
         ) as client:
+            client._hw_version = HWVersion.PCIE
+            client._application_version = "2.3.2"
             yield client, mock_ws
 
 
 def _sent_reports(mock_ws: AsyncMock) -> list[bytes]:
     return [call.args[0] for call in mock_ws.send_bytes.call_args_list]
+
+
+@pytest.fixture
+async def legacy_client_with_mock_ws() -> AsyncGenerator[
+    tuple[NanoKVMClient, AsyncMock], Any
+]:
+    """Fixture that provides a pre-2.3.2 client and mocked WebSocket."""
+    mock_ws = AsyncMock()
+    mock_ws.closed = False
+
+    with patch(
+        "aiohttp.ClientSession.ws_connect", new_callable=AsyncMock, return_value=mock_ws
+    ):
+        async with NanoKVMClient(
+            "http://localhost:8888/api/", token="test-token"
+        ) as client:
+            client._hw_version = HWVersion.PCIE
+            client._application_version = "2.3.1"
+            yield client, mock_ws
+
+
+def _sent_events(mock_ws: AsyncMock) -> list[list[int]]:
+    return [call.args[0] for call in mock_ws.send_json.call_args_list]
 
 
 async def test_mouse_move_abs_sends_hid_report(
@@ -95,6 +120,63 @@ async def test_mouse_scroll_encodes_vertical_wheel(
     assert _sent_reports(mock_ws) == [bytes([2, 0, 0, 0, 231])]
 
 
+async def test_legacy_mouse_move_abs_sends_json_event(
+    legacy_client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Non-Pro versions through 2.3.1 use the original JSON protocol."""
+    client, mock_ws = legacy_client_with_mock_ws
+
+    await client.mouse_move_abs(0.5, 0.5)
+
+    assert _sent_events(mock_ws) == [[2, 2, 0, 16384, 16384]]
+    mock_ws.send_bytes.assert_not_called()
+
+
+async def test_legacy_mouse_move_and_scroll_preserve_json_values(
+    legacy_client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Legacy relative movement and scrolling retain their integer payloads."""
+    client, mock_ws = legacy_client_with_mock_ws
+
+    await client.mouse_move_rel(0.1, -0.1)
+    await client.mouse_scroll(0.1, -0.2)
+
+    assert _sent_events(mock_ws) == [
+        [2, 3, 0, 3276, -3276],
+        [2, 4, 0, 3276, -6553],
+    ]
+
+
+async def test_legacy_mouse_buttons_use_original_event_shape(
+    legacy_client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Legacy button events carry one button value rather than a HID bitmask."""
+    client, mock_ws = legacy_client_with_mock_ws
+
+    await client.mouse_down(MouseButton.LEFT)
+    await client.mouse_down(MouseButton.RIGHT)
+    await client.mouse_up()
+
+    assert _sent_events(mock_ws) == [
+        [2, 1, 1, 0, 0],
+        [2, 1, 2, 0, 0],
+        [2, 0, 0, 0, 0],
+    ]
+
+
+async def test_pro_mouse_uses_binary_protocol(
+    client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """The Pro hardware family uses binary HID reports regardless of version."""
+    client, mock_ws = client_with_mock_ws
+    client._hw_version = HWVersion.PRO
+    client._application_version = "1.0.0"
+
+    await client.mouse_move_abs(0.5, 0.5)
+
+    assert _sent_reports(mock_ws) == [bytes([2, 0, 0, 64, 0, 64, 0])]
+
+
 async def test_context_manager_cleanup() -> None:
     """Test that context manager properly closes WebSocket and session."""
     mock_ws = AsyncMock()
@@ -106,6 +188,8 @@ async def test_context_manager_cleanup() -> None:
         async with NanoKVMClient(
             "http://localhost:8888/api/", token="test-token"
         ) as client:
+            client._hw_version = HWVersion.PCIE
+            client._application_version = "2.3.2"
             await client.mouse_move_abs(0.0, 0.0)
             assert client._ws is not None
             assert client._session is not None

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -167,14 +167,28 @@ async def test_legacy_mouse_buttons_use_original_event_shape(
 async def test_pro_mouse_uses_binary_protocol(
     client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
 ) -> None:
-    """The Pro hardware family uses binary HID reports regardless of version."""
+    """Pro application versions from 1.2.6 use binary HID reports."""
     client, mock_ws = client_with_mock_ws
     client._hw_version = HWVersion.PRO
-    client._application_version = "1.0.0"
+    client._application_version = "1.2.6"
 
     await client.mouse_move_abs(0.5, 0.5)
 
     assert _sent_reports(mock_ws) == [bytes([2, 0, 0, 64, 0, 64, 0])]
+
+
+async def test_legacy_pro_mouse_uses_json_protocol(
+    legacy_client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Pro application versions before 1.2.6 use the legacy JSON protocol."""
+    client, mock_ws = legacy_client_with_mock_ws
+    client._hw_version = HWVersion.PRO
+    client._application_version = "1.2.5"
+
+    await client.mouse_move_abs(0.5, 0.5)
+
+    assert _sent_events(mock_ws) == [[2, 2, 0, 16384, 16384]]
+    mock_ws.send_bytes.assert_not_called()
 
 
 async def test_context_manager_cleanup() -> None:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,5 +1,6 @@
 """Tests for SSL/TLS configuration and password obfuscation."""
 
+import logging
 from pathlib import Path
 import ssl
 from unittest.mock import MagicMock, patch
@@ -109,6 +110,30 @@ async def test_authenticate_with_plain_text_password() -> None:
             request_json = calls[0].kwargs.get("json")
             assert request_json["username"] == "root"
             assert request_json["password"] == "password123"
+
+
+async def test_authentication_debug_logs_redact_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Authentication logs must not contain passwords or returned tokens."""
+    password = "password-must-not-be-logged"
+    token = "token-must-not-be-logged"
+    caplog.set_level(logging.DEBUG, logger="nanokvm.client")
+
+    async with NanoKVMClient(
+        "https://kvm.local/api/", use_password_obfuscation=False
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "https://kvm.local/api/auth/login",
+                payload={"code": 0, "msg": "success", "data": {"token": token}},
+            )
+            m.get(_HARDWARE_URL, payload=_HARDWARE_PAYLOAD)
+
+            await client.authenticate("root", password)
+
+    assert password not in caplog.text
+    assert token not in caplog.text
 
 
 async def test_authenticate_with_obfuscated_password() -> None:


### PR DESCRIPTION
## Summary

- Add version-aware mouse protocol handling:
  - Binary HID for non-Pro firmware >=2.3.2.
  - Binary HID for Pro firmware >=1.2.6.
  - Legacy JSON events for older firmware.
- Encode HID button state, absolute movement, relative movement, and wheel scrolling correctly.
- Keep MJPEG streams open beyond the normal request timeout.
- Prevent request and response bodies from exposing sensitive data in debug logs.
- Recognize successful and failed terminal states for image downloads.
- Keep the test suite compatible with current aiohttp releases using `aioresponses-ng`.
- Preserve the existing client architecture and public API.

## Validation

- 70 tests passed.
- 83% coverage with Python 3.14 and aiohttp 3.14.
- Ruff, formatting, codespell, and mypy passed.
- GitHub Actions CI passed.