### PR TITLE
Harden NanoKVM mouse WebSocket lifecycle

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -321,6 +321,7 @@ class NanoKVMClient:
         self._token = token
         self._request_timeout = request_timeout
         self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._ws_lock = asyncio.Lock()
         self._mouse_buttons = 0
         self._mouse_mode = "relative"
         self._mouse_abs_position = (0, 0)
@@ -415,9 +416,7 @@ class NanoKVMClient:
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Async context manager exit - cleanup resources."""
         # Close WebSocket connection
-        if self._ws is not None and not self._ws.closed:
-            await self._ws.close()
-            self._ws = None
+        await self._close_ws()
 
         # Close HTTP session
         if self._session is not None and not self._external_session_provided:
@@ -689,13 +688,13 @@ class NanoKVMClient:
 
     async def logout(self) -> None:
         """Log out and clear the session token."""
-        if not self._token or self._token == "disabled":
-            return
-
         try:
-            await self._api_request_json(hdrs.METH_POST, "/auth/logout")
+            if self._token and self._token != "disabled":
+                await self._api_request_json(hdrs.METH_POST, "/auth/logout")
         finally:
             self._token = None
+            self._mouse_buttons = 0
+            await self._close_ws()
 
     async def change_password(self, username: str, new_password: str) -> None:
         """Change the KVM password."""
@@ -1820,9 +1819,32 @@ class NanoKVMClient:
 
     # ── Mouse (WebSocket) ──────────────────────────────────────────────
 
+    async def _close_ws(self) -> None:
+        """Close and forget the current WebSocket connection."""
+        async with self._ws_lock:
+            ws = self._ws
+            self._ws = None
+            if ws is not None and not ws.closed:
+                await ws.close()
+
+    async def _invalidate_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Forget a failed WebSocket without closing a replacement connection."""
+        async with self._ws_lock:
+            if self._ws is ws:
+                self._ws = None
+            if not ws.closed:
+                await ws.close()
+
     async def _get_ws(self) -> aiohttp.ClientWebSocketResponse:
         """Get or create WebSocket connection for mouse events."""
-        if self._ws is None or self._ws.closed:
+        async with self._ws_lock:
+            if self._ws is not None and not self._ws.closed:
+                return self._ws
+
+            if self._ws is not None:
+                await self._ws.close()
+                self._ws = None
+
             if not self._token:
                 raise NanoKVMNotAuthenticatedError("Client is not authenticated")
 
@@ -1838,7 +1860,7 @@ class NanoKVMClient:
                 headers={"Cookie": f"nano-kvm-token={self._token}"},
                 ssl=self._ssl_config,
             )
-        return self._ws
+            return self._ws
 
     async def _uses_binary_mouse_protocol(self) -> bool:
         """Select the mouse wire format supported by the connected device.
@@ -1909,7 +1931,11 @@ class NanoKVMClient:
     async def _send_mouse_report(self, report: bytes) -> None:
         """Send a binary NanoKVM mouse event and HID report."""
         ws = await self._get_ws()
-        await ws.send_bytes(bytes((2,)) + report)
+        try:
+            await ws.send_bytes(bytes((2,)) + report)
+        except (aiohttp.ClientConnectionError, ConnectionError, RuntimeError):
+            await self._invalidate_ws(ws)
+            raise
 
     async def _send_legacy_mouse_event(
         self, event_type: int, button_state: int, x: float, y: float
@@ -1926,7 +1952,11 @@ class NanoKVMClient:
 
         message = [2, event_type, button_state, x_value, y_value]
         _LOGGER.debug("Sending legacy mouse event: %s", message)
-        await ws.send_json(message)
+        try:
+            await ws.send_json(message)
+        except (aiohttp.ClientConnectionError, ConnectionError, RuntimeError):
+            await self._invalidate_ws(ws)
+            raise
 
     async def mouse_move_abs(self, x: float, y: float) -> None:
         """

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -1,12 +1,13 @@
 """Tests for mouse control functionality."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nanokvm.client import NanoKVMClient
+from nanokvm.client import NanoKVMClient, NanoKVMNotAuthenticatedError
 from nanokvm.models import HWVersion, MouseButton
 
 
@@ -162,6 +163,79 @@ async def test_legacy_mouse_buttons_use_original_event_shape(
         [2, 1, 2, 0, 0],
         [2, 0, 0, 0, 0],
     ]
+
+
+async def test_concurrent_first_mouse_use_creates_one_websocket() -> None:
+    """Concurrent first use shares one lazily-created WebSocket."""
+    mock_ws = AsyncMock()
+    mock_ws.closed = False
+    connect_started = asyncio.Event()
+    allow_connect = asyncio.Event()
+    connect_count = 0
+
+    async def connect(*_args: Any, **_kwargs: Any) -> AsyncMock:
+        nonlocal connect_count
+        connect_count += 1
+        connect_started.set()
+        await allow_connect.wait()
+        return mock_ws
+
+    with patch("aiohttp.ClientSession.ws_connect", new=connect):
+        async with NanoKVMClient(
+            "http://localhost:8888/api/", token="test-token"
+        ) as client:
+            client._hw_version = HWVersion.PCIE
+            client._application_version = "2.3.2"
+            first = asyncio.create_task(client.mouse_move_rel(0.1, 0.0))
+            await connect_started.wait()
+            second = asyncio.create_task(client.mouse_move_rel(0.0, 0.1))
+            allow_connect.set()
+            await asyncio.gather(first, second)
+
+    assert connect_count == 1
+    assert mock_ws.send_bytes.await_count == 2
+
+
+async def test_mouse_send_reconnects_after_transport_failure() -> None:
+    """A failed send invalidates the cached WebSocket for the next operation."""
+    first_ws = AsyncMock()
+    first_ws.closed = False
+    first_ws.send_bytes.side_effect = ConnectionResetError()
+    second_ws = AsyncMock()
+    second_ws.closed = False
+    connect = AsyncMock(side_effect=[first_ws, second_ws])
+
+    with patch("aiohttp.ClientSession.ws_connect", new=connect):
+        async with NanoKVMClient(
+            "http://localhost:8888/api/", token="test-token"
+        ) as client:
+            client._hw_version = HWVersion.PCIE
+            client._application_version = "2.3.2"
+            with pytest.raises(ConnectionResetError):
+                await client.mouse_move_rel(0.1, 0.0)
+            await client.mouse_move_rel(0.1, 0.0)
+
+    assert connect.await_count == 2
+    first_ws.close.assert_awaited_once()
+
+
+async def test_logout_closes_websocket_and_prevents_further_mouse_input(
+    client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Logout invalidates the transport and local pressed-button state."""
+    client, mock_ws = client_with_mock_ws
+    await client.mouse_move_rel(0.1, 0.0)
+    client._mouse_buttons = int(MouseButton.LEFT)
+
+    with patch.object(client, "_api_request_json", new_callable=AsyncMock):
+        await client.logout()
+
+    assert client.token is None
+    assert client._mouse_buttons == 0
+    mock_ws.close.assert_awaited_once()
+    assert client._ws is None
+    with pytest.raises(NanoKVMNotAuthenticatedError, match="not authenticated"):
+        await client.mouse_move_rel(0.1, 0.0)
 
 
 async def test_pro_mouse_uses_binary_protocol(


### PR DESCRIPTION
## Summary

- Serialize lazy WebSocket creation to prevent duplicate connections.
- Invalidate and close the cached WebSocket after transport failures.
- Reconnect automatically on the next mouse operation.
- Close the WebSocket and clear held mouse buttons during logout and context cleanup.
- Add regression tests for concurrent initialization, reconnects, logout cleanup, and unauthenticated mouse input.

## Validation

- `pre-commit run --show-diff-on-failure --all-files`
- CI-equivalent pytest run: 73 passed
- Coverage: 84%
- Validated with a no-op mouse movement and logout against real NanoKVM devices running firmware 2.5.0 and 1.2.15.