### PR TITLE
Harden API response validation and resource handling

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -144,7 +144,7 @@ from .models.pro import (
 )
 from .utils import obfuscate_password
 
-T = TypeVar("T")
+T = TypeVar("T", bound=BaseModel)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -406,10 +406,9 @@ class NanoKVMClient:
 
     async def __aenter__(self) -> NanoKVMClient:
         """Async context manager entry."""
+        self._ssl_config = await asyncio.to_thread(self._create_ssl_context)
         if self._session is None and not self._external_session_provided:
             self._session = ClientSession()
-
-        self._ssl_config = await asyncio.to_thread(self._create_ssl_context)
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -550,7 +549,6 @@ class NanoKVMClient:
         ) as response:
             try:
                 raw_response = await response.json(content_type=None)
-                _LOGGER.debug("Raw JSON response data: %s", raw_response)
             except (json.JSONDecodeError, ValidationError) as err:
                 raise NanoKVMInvalidResponseError(
                     f"Invalid JSON response received: {err}"
@@ -565,14 +563,9 @@ class NanoKVMClient:
     ) -> T | None:
         """Validate the shared NanoKVM response envelope."""
         try:
-            if response_model is None:
-                api_response = ApiResponse[Any].model_validate(raw_response)
-            else:
-                api_response = ApiResponse[response_model].model_validate(raw_response)  # type: ignore[valid-type]
+            api_response = ApiResponse[Any].model_validate(raw_response)
         except ValidationError as err:
-            raise NanoKVMInvalidResponseError(
-                f"Invalid JSON response received: {err}"
-            ) from err
+            raise NanoKVMInvalidResponseError("Invalid API response envelope") from err
 
         _LOGGER.debug(
             "Got API response: code=%s msg=%s", api_response.code, api_response.msg
@@ -589,7 +582,13 @@ class NanoKVMClient:
         if response_model is None:
             return None
 
-        return api_response.data
+        if api_response.data is None:
+            raise NanoKVMInvalidResponseError("Successful API response is missing data")
+
+        try:
+            return response_model.model_validate(api_response.data)
+        except ValidationError as err:
+            raise NanoKVMInvalidResponseError("Invalid data in API response") from err
 
     @overload
     async def _upload_file(
@@ -1630,7 +1629,9 @@ class NanoKVMClient:
 
     def _parse_jpeg_from_bytes(self, data: bytes) -> Image.Image:
         """Parse JPEG image from bytes."""
-        return Image.open(io.BytesIO(data), formats=["JPEG"])
+        with Image.open(io.BytesIO(data), formats=["JPEG"]) as image:
+            image.load()
+            return image.copy()
 
     async def mjpeg_stream(self) -> AsyncIterator[Image.Image]:
         """Stream MJPEG frames."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "cryptography",
     "yarl",
     "pillow",
-    "pydantic",
+    "pydantic>=2.0",
     "paramiko",
 ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import logging
 from pathlib import Path
 
 import aiohttp
@@ -12,6 +13,7 @@ import yarl
 from nanokvm.client import (
     NanoKVMApiError,
     NanoKVMClient,
+    NanoKVMInvalidResponseError,
     NanoKVMNotSupportedError,
     _parse_version,
     _version_at_least,
@@ -120,6 +122,94 @@ async def test_get_images_empty() -> None:
 
             assert response is not None
             assert len(response.files) == 0
+
+
+async def test_typed_success_response_requires_data() -> None:
+    """A typed endpoint rejects a successful response without its payload."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/storage/image",
+                payload={"code": 0, "msg": "success", "data": None},
+            )
+
+            with pytest.raises(NanoKVMInvalidResponseError, match="missing data"):
+                await client.get_images()
+
+
+async def test_api_error_data_is_not_validated_as_success_model() -> None:
+    """An error envelope is classified before its endpoint data is parsed."""
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:8888/api/storage/image",
+                payload={
+                    "code": -1,
+                    "msg": "failed to list images",
+                    "data": {"synthetic": "unexpected"},
+                },
+            )
+
+            with pytest.raises(NanoKVMApiError) as exc_info:
+                await client.get_images()
+
+            assert exc_info.value.code == -1
+
+
+def test_invalid_response_error_does_not_echo_payload() -> None:
+    """Malformed response errors do not include arbitrary response values."""
+    client = NanoKVMClient("http://localhost:8888/api/")
+    secret = "SYNTHETIC_SECRET_VALUE"
+
+    with pytest.raises(NanoKVMInvalidResponseError) as exc_info:
+        client._validate_api_response(
+            {"msg": "invalid", "data": {"token": secret}},
+        )
+
+    assert secret not in str(exc_info.value)
+
+
+async def test_form_response_is_not_logged(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Multipart responses are not emitted verbatim to debug logs."""
+    script = tmp_path / "test.sh"
+    script.write_text("#!/bin/sh\ntrue\n")
+    secret = "SYNTHETIC_FORM_VALUE"
+    caplog.set_level(logging.DEBUG, logger="nanokvm.client")
+
+    async with NanoKVMClient(
+        "http://localhost:8888/api/", token="test-token"
+    ) as client:
+        with aioresponses() as m:
+            m.post(
+                "http://localhost:8888/api/vm/script/upload",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {"file": secret},
+                },
+            )
+
+            await client.upload_script(script)
+
+    assert secret not in caplog.text
+
+
+def test_parse_jpeg_returns_fully_loaded_image() -> None:
+    """JPEG parsing returns an image detached from the source stream."""
+    image_buffer = io.BytesIO()
+    Image.new("RGB", (2, 2), color=(1, 2, 3)).save(image_buffer, format="JPEG")
+    client = NanoKVMClient("http://localhost:8888/api/")
+
+    image = client._parse_jpeg_from_bytes(image_buffer.getvalue())
+
+    assert image.getpixel((0, 0))
+    assert getattr(image, "fp", None) is None
 
 
 async def test_mjpeg_stream_allows_frames_after_request_timeout() -> None:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -62,6 +62,22 @@ async def test_nonexistent_ca_cert_raises_error() -> None:
         client._create_ssl_context()
 
 
+async def test_context_manager_closes_session_when_ssl_setup_fails() -> None:
+    """A failed context entry does not leak the internally-created session."""
+    client = NanoKVMClient(
+        "https://kvm.local/api/", ssl_ca_cert="/path/that/does/not/exist.pem"
+    )
+
+    try:
+        with pytest.raises(FileNotFoundError):
+            await client.__aenter__()
+
+        assert client._session is None or client._session.closed
+    finally:
+        if client._session is not None and not client._session.closed:
+            await client._session.close()
+
+
 async def test_http_url_works_regardless_of_ssl_config() -> None:
     """Test that HTTP URL (not HTTPS) works regardless of SSL config."""
     client = NanoKVMClient("http://kvm.local/api/", verify_ssl=False)


### PR DESCRIPTION
## Summary

- Validate the API response envelope before validating endpoint-specific payloads.
- Classify API errors before parsing success response models.
- Reject typed successful responses that omit their `data` payload.
- Avoid exposing response contents in validation errors and multipart debug logs.
- Require Pydantic 2 or newer.
- Create the SSL configuration before opening the internal HTTP session.
- Fully load and detach JPEG frames from their source stream.

## Validation

- `pre-commit run --show-diff-on-failure --all-files`
- CI-equivalent pytest run: 76 passed
- Coverage: 83%
- Validated read-only API operations against real NanoKVM devices running application versions 1.2.15 and 2.5.0.