### PR TITLE
Harden NanoKVM SSH connections and command execution

### DIFF
--- a/nanokvm/ssh_client.py
+++ b/nanokvm/ssh_client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from os import PathLike
 
 import paramiko
 
@@ -31,22 +33,37 @@ class NanoKVMSSH:
     """SSH client for NanoKVM terminal access."""
 
     def __init__(
-        self, host: str, username: str = DEFAULT_SSH_USERNAME, port: int = 22
+        self,
+        host: str,
+        username: str = DEFAULT_SSH_USERNAME,
+        port: int = 22,
+        *,
+        known_hosts: str | PathLike[str] | None = None,
+        allow_unknown_host_key: bool = False,
     ) -> None:
         """Initialize the SSH client."""
         self.host = host
         self.port = port
         self.username = username
+        self.known_hosts = known_hosts
+        self.allow_unknown_host_key = allow_unknown_host_key
         self.ssh_client: paramiko.SSHClient | None = None
+        self._active_channel: paramiko.Channel | None = None
 
     async def authenticate(self, password: str) -> None:
         """Authenticate with SSH using password."""
         loop = asyncio.get_running_loop()
-        self.ssh_client = paramiko.SSHClient()
-        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client = paramiko.SSHClient()
 
         try:
-            client = self.ssh_client  # Capture for lambda
+            client.load_system_host_keys()
+            if self.known_hosts is not None:
+                client.load_host_keys(str(self.known_hosts))
+            client.set_missing_host_key_policy(
+                paramiko.AutoAddPolicy()
+                if self.allow_unknown_host_key
+                else paramiko.RejectPolicy()
+            )
             await loop.run_in_executor(
                 None,
                 lambda: client.connect(
@@ -57,11 +74,14 @@ class NanoKVMSSH:
                     timeout=10,
                 ),
             )
+            self.ssh_client = client
         except paramiko.AuthenticationException as e:
+            client.close()
             raise NanoKVMSSHAuthenticationError(
                 f"SSH authentication failed: {e}"
             ) from e
         except (paramiko.SSHException, paramiko.BadHostKeyException, OSError) as e:
+            client.close()
             raise NanoKVMSSHAuthenticationError(f"SSH connection failed: {e}") from e
 
     async def disconnect(self) -> None:
@@ -70,30 +90,46 @@ class NanoKVMSSH:
             self.ssh_client.close()
             self.ssh_client = None
 
-    async def run_command(self, command: str, timeout: int = 30) -> str:
+    async def run_command(self, command: str, timeout: float = 30) -> str:
         """Run a command via SSH and return output."""
         if not self.ssh_client:
             raise NanoKVMSSHNotConnectedError(
                 "SSH not connected, call authenticate first"
             )
         loop = asyncio.get_running_loop()
+        command_future = loop.run_in_executor(None, self._exec_command_sync, command)
         try:
-            output, error = await asyncio.wait_for(
-                loop.run_in_executor(None, self._exec_command_sync, command),
+            output, error, exit_status = await asyncio.wait_for(
+                command_future,
                 timeout=timeout,
             )
-            if error:
-                raise NanoKVMSSHCommandError(f"SSH command error: {error}")
+            if exit_status != 0:
+                detail = error.strip() or output.strip()
+                suffix = f": {detail}" if detail else ""
+                raise NanoKVMSSHCommandError(
+                    f"SSH command exited with status {exit_status}{suffix}"
+                )
             return output.strip()
         except asyncio.TimeoutError:
+            if self._active_channel is not None:
+                self._active_channel.close()
             raise NanoKVMSSHCommandError(
                 f"SSH command timed out after {timeout} seconds"
             ) from None
 
-    def _exec_command_sync(self, command: str) -> tuple[str, str]:
+    def _exec_command_sync(self, command: str) -> tuple[str, str, int]:
         """Synchronous SSH command execution."""
         assert self.ssh_client is not None  # Should be set after authenticate()
         stdin, stdout, stderr = self.ssh_client.exec_command(command)
-        output = stdout.read().decode("utf-8")
-        error = stderr.read().decode("utf-8")
-        return output, error
+        del stdin
+        channel = stdout.channel
+        self._active_channel = channel
+        try:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                stdout_future = executor.submit(stdout.read)
+                stderr_future = executor.submit(stderr.read)
+                output = stdout_future.result().decode("utf-8")
+                error = stderr_future.result().decode("utf-8")
+            return output, error, channel.recv_exit_status()
+        finally:
+            self._active_channel = None

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -1,0 +1,143 @@
+"""Tests for NanoKVM SSH access."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import Mock, patch
+
+import paramiko
+import pytest
+
+from nanokvm.ssh_client import NanoKVMSSH, NanoKVMSSHCommandError
+
+
+class _FakeChannel:
+    def __init__(self, exit_status: int = 0) -> None:
+        self.exit_status = exit_status
+        self.closed = False
+        self.close_event = threading.Event()
+
+    def recv_exit_status(self) -> int:
+        return self.exit_status
+
+    def close(self) -> None:
+        self.closed = True
+        self.close_event.set()
+
+
+class _FakeStream:
+    def __init__(self, channel: _FakeChannel, data: bytes) -> None:
+        self.channel = channel
+        self.data = data
+
+    def read(self) -> bytes:
+        return self.data
+
+
+class _CoordinatedStream(_FakeStream):
+    def __init__(
+        self,
+        channel: _FakeChannel,
+        data: bytes,
+        before_read: threading.Event | None = None,
+        signal_on_read: threading.Event | None = None,
+    ) -> None:
+        super().__init__(channel, data)
+        self.before_read = before_read
+        self.signal_on_read = signal_on_read
+
+    def read(self) -> bytes:
+        if self.signal_on_read is not None:
+            self.signal_on_read.set()
+        if self.before_read is not None:
+            self.before_read.wait(1)
+        return super().read()
+
+
+class _BlockingStream(_FakeStream):
+    def read(self) -> bytes:
+        self.channel.close_event.wait(1)
+        return b""
+
+
+def _fake_client(
+    stdout: Any,
+    stderr: Any,
+) -> Mock:
+    fake_client = Mock()
+    fake_client.exec_command.return_value = (Mock(), stdout, stderr)
+    return fake_client
+
+
+async def test_run_command_uses_exit_status_and_allows_stderr_warning() -> None:
+    channel = _FakeChannel(exit_status=0)
+    client = NanoKVMSSH("kvm.local")
+    client.ssh_client = _fake_client(
+        _FakeStream(channel, b"ok\n"),
+        _FakeStream(channel, b"warning\n"),
+    )
+
+    assert await client.run_command("synthetic") == "ok"
+    assert channel.recv_exit_status() == 0
+
+
+async def test_run_command_raises_for_nonzero_exit_status_without_stderr() -> None:
+    channel = _FakeChannel(exit_status=42)
+    client = NanoKVMSSH("kvm.local")
+    client.ssh_client = _fake_client(
+        _FakeStream(channel, b"partial output\n"),
+        _FakeStream(channel, b""),
+    )
+
+    with pytest.raises(NanoKVMSSHCommandError, match="status 42"):
+        await client.run_command("synthetic")
+
+
+async def test_run_command_drains_stdout_and_stderr_concurrently() -> None:
+    channel = _FakeChannel(exit_status=0)
+    stderr_read = threading.Event()
+    client = NanoKVMSSH("kvm.local")
+    client.ssh_client = _fake_client(
+        _CoordinatedStream(channel, b"out\n", before_read=stderr_read),
+        _CoordinatedStream(channel, b"warn\n", signal_on_read=stderr_read),
+    )
+
+    assert await client.run_command("synthetic", timeout=0.5) == "out"
+
+
+async def test_run_command_closes_channel_when_timed_out() -> None:
+    channel = _FakeChannel()
+    client = NanoKVMSSH("kvm.local")
+    client.ssh_client = _fake_client(
+        _BlockingStream(channel, b""),
+        _BlockingStream(channel, b""),
+    )
+
+    with pytest.raises(NanoKVMSSHCommandError, match="timed out"):
+        await client.run_command("synthetic", timeout=0.01)
+
+    assert channel.closed
+
+
+@pytest.mark.asyncio
+async def test_authenticate_uses_strict_host_key_policy_by_default() -> None:
+    fake_client = Mock()
+    with patch("nanokvm.ssh_client.paramiko.SSHClient", return_value=fake_client):
+        client = NanoKVMSSH("kvm.local")
+        await client.authenticate("synthetic-password")
+
+    fake_client.load_system_host_keys.assert_called_once_with()
+    policy = fake_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.RejectPolicy)
+
+
+@pytest.mark.asyncio
+async def test_authenticate_can_explicitly_allow_unknown_host_key() -> None:
+    fake_client = Mock()
+    with patch("nanokvm.ssh_client.paramiko.SSHClient", return_value=fake_client):
+        client = NanoKVMSSH("kvm.local", allow_unknown_host_key=True)
+        await client.authenticate("synthetic-password")
+
+    policy = fake_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.AutoAddPolicy)


### PR DESCRIPTION
## Summary

- Reject unknown SSH host keys by default.
- Support explicit `known_hosts` files and opt-in unknown host keys.
- Drain stdout and stderr concurrently to avoid blocked commands.
- Use the SSH exit status to determine command success.
- Close the active channel when a command times out.
- Add regression tests for host-key policy, exit status, stderr handling, concurrent output, and timeout cleanup.

## Validation

- `pre-commit run --show-diff-on-failure --all-files`
- CI-equivalent pytest run: 76 passed
- Coverage: 86%
- Read-only SSH commands validated against both real NanoKVM devices.