### PR TITLE
Fix legacy mouse input scaling and cancellation cleanup

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -1917,9 +1917,15 @@ class NanoKVMClient:
         """Send a mouse event using the pre-2.3.2 JSON wire format."""
         ws = await self._get_ws()
 
-        if event_type in (2, 3, 4):
+        if event_type == 2:
             x_value = int(x * 32768)
             y_value = int(y * 32768)
+        elif event_type == 3:
+            x_value = self._relative_value(x)
+            y_value = self._relative_value(y)
+        elif event_type == 4:
+            x_value = 0
+            y_value = 1 if y > 0 else -1 if y < 0 else 0
         else:
             x_value = int(x)
             y_value = int(y)
@@ -2020,12 +2026,17 @@ class NanoKVMClient:
             # Small delay to ensure position update
             await asyncio.sleep(0.05)
 
-        # Send mouse down
-        await self.mouse_down(button)
-        # Small delay between down and up
-        await asyncio.sleep(0.05)
-        # Send mouse up
-        await self.mouse_up()
+        pressed = False
+        try:
+            # Send mouse down
+            await self.mouse_down(button)
+            pressed = True
+            # Small delay between down and up
+            await asyncio.sleep(0.05)
+        finally:
+            if pressed:
+                # Always release after a successful press, including cancellation.
+                await self.mouse_up()
 
     async def mouse_scroll(self, dx: float, dy: float) -> None:
         """

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -1,5 +1,6 @@
 """Tests for mouse control functionality."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -132,19 +133,44 @@ async def test_legacy_mouse_move_abs_sends_json_event(
     mock_ws.send_bytes.assert_not_called()
 
 
-async def test_legacy_mouse_move_and_scroll_preserve_json_values(
+async def test_legacy_mouse_move_and_scroll_use_legacy_ranges(
     legacy_client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
 ) -> None:
-    """Legacy relative movement and scrolling retain their integer payloads."""
+    """Legacy relative movement and scrolling use the signed HID ranges."""
     client, mock_ws = legacy_client_with_mock_ws
 
     await client.mouse_move_rel(0.1, -0.1)
     await client.mouse_scroll(0.1, -0.2)
 
     assert _sent_events(mock_ws) == [
-        [2, 3, 0, 3276, -3276],
-        [2, 4, 0, 3276, -6553],
+        [2, 3, 0, 13, -13],
+        [2, 4, 0, 0, -1],
     ]
+
+
+async def test_mouse_click_releases_button_when_cancelled(
+    client_with_mock_ws: tuple[NanoKVMClient, AsyncMock],
+) -> None:
+    """Cancelling the delay between mouse down and up still releases the button."""
+    client, mock_ws = client_with_mock_ws
+    sleep_started = asyncio.Event()
+
+    async def block_sleep(_delay: float) -> None:
+        sleep_started.set()
+        await asyncio.Event().wait()
+
+    with patch("nanokvm.client.asyncio.sleep", side_effect=block_sleep):
+        task = asyncio.create_task(client.mouse_click())
+        await sleep_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert _sent_reports(mock_ws) == [
+        bytes([2, 1, 0, 0, 0]),
+        bytes([2, 0, 0, 0, 0]),
+    ]
+    assert client._mouse_buttons == 0
 
 
 async def test_legacy_mouse_buttons_use_original_event_shape(


### PR DESCRIPTION
## Summary

- Encode legacy relative mouse movement in the signed `-127..127` range.
- Encode legacy scrolling as a vertical direction with `x=0`.
- Ensure `mouse_click()` releases the button when cancelled after pressing.
- Add regression tests for legacy movement, scrolling, and cancellation cleanup.

## Validation

- `pre-commit run --show-diff-on-failure --all-files`
- CI-equivalent pytest run: 71 passed
- Coverage: 83%
- Legacy JSON mouse payloads are covered by protocol-specific regression tests.