### PR TITLE
Support current-password authentication on NanoKVM 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ except NanoKVMPermissionError as error:
     print(error.status, error.method, error.path)
 ```
 
+### Changing a password
+
+The password method keeps its two positional arguments and accepts the current
+password as a keyword-only argument:
+
+```python
+await client.change_password(
+    "synthetic-user",
+    "new-password",
+    current_password="current-password",
+)
+```
+
+On non-Pro firmware version 2.5.1 and newer, the current password is required
+and the username must be the authenticated account. A successful change clears
+the local session, so authenticate again before making another request.
+
 ## SSH Usage
 
 ```python

--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -33,6 +33,7 @@ from .models.common import (
     ApiResponse,
     ApiResponseCode,
     ChangePasswordReq,
+    ChangePasswordV251Req,
     ConnectWifiReq,
     DeleteImageReq,
     DeleteMacReq,
@@ -209,6 +210,7 @@ F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
 _VERSION_RE = re.compile(r"^v?(\d+(?:\.\d+)*)$")
 _BINARY_MOUSE_MIN_NON_PRO_VERSION = "2.3.2"
 _BINARY_MOUSE_MIN_PRO_VERSION = "1.2.6"
+_CURRENT_PASSWORD_MIN_NON_PRO_VERSION = "2.5.1"
 
 
 def _parse_version(version: str) -> tuple[int, ...] | None:
@@ -763,8 +765,66 @@ class NanoKVMClient:
         self._mouse_buttons = 0
         await self._close_ws()
 
-    async def change_password(self, username: str, new_password: str) -> None:
-        """Change the KVM password."""
+    async def _uses_current_password_contract(self) -> bool:
+        """Determine whether this device uses the 2.5.1 password contract."""
+        if self._hw_version is None:
+            if self._token is None:
+                raise NanoKVMNotAuthenticatedError("Client is not authenticated")
+            await self.detect_hardware()
+
+        if self._hw_version == HWVersion.PRO:
+            return False
+
+        if self._application_version is None:
+            if self._token is None:
+                raise NanoKVMNotAuthenticatedError("Client is not authenticated")
+            await self.detect_versions()
+
+        if self._application_version is None:
+            raise NanoKVMError(
+                "Application version must be identified before changing the password"
+            )
+
+        parsed_version = _parse_version(self._application_version)
+        minimum_version = _parse_version(_CURRENT_PASSWORD_MIN_NON_PRO_VERSION)
+        if parsed_version is None or minimum_version is None:
+            raise NanoKVMError(
+                "Application version must be identified before changing the password"
+            )
+
+        return parsed_version >= minimum_version
+
+    async def change_password(
+        self,
+        username: str,
+        new_password: str,
+        *,
+        current_password: str | None = None,
+    ) -> None:
+        """Change the KVM password for the authenticated account."""
+        if await self._uses_current_password_contract():
+            if not current_password or not current_password.strip():
+                raise ValueError(
+                    "current_password is required for NanoKVM 2.5.1 and newer"
+                )
+
+            account = await self.get_account()
+            if account.username != username:
+                raise ValueError(
+                    "username must match the authenticated account on NanoKVM 2.5.1"
+                )
+
+            await self._api_request_json(
+                hdrs.METH_POST,
+                "/auth/password",
+                data=ChangePasswordV251Req(
+                    current_password=obfuscate_password(current_password),
+                    password=obfuscate_password(new_password),
+                ),
+            )
+            await self._clear_local_session()
+            return
+
         if self._use_password_obfuscation is None:
             raise ValueError(
                 "Password mode is unknown. Authenticate first or set "

--- a/nanokvm/models/common.py
+++ b/nanokvm/models/common.py
@@ -156,6 +156,13 @@ class ChangePasswordReq(BaseModel):
     password: str
 
 
+class ChangePasswordV251Req(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    current_password: str = Field(alias="currentPassword")
+    password: str
+
+
 class IsPasswordUpdatedRsp(BaseModel):
     is_updated: bool = Field(alias="isUpdated")
 

--- a/tests/test_current_password_auth.py
+++ b/tests/test_current_password_auth.py
@@ -1,0 +1,242 @@
+"""Regression tests for NanoKVM 2.5.1 self-service password changes."""
+
+from unittest.mock import AsyncMock, patch
+
+from aioresponses import aioresponses
+import pytest
+import yarl
+
+from nanokvm.client import NanoKVMApiError, NanoKVMClient, NanoKVMError
+from nanokvm.models import HWVersion
+
+_BASE_URL = "http://kvm.local/api/"
+_ACCOUNT_URL = f"{_BASE_URL}auth/account"
+_PASSWORD_URL = f"{_BASE_URL}auth/password"
+
+
+def _account_payload(username: str = "synthetic-user") -> dict[str, object]:
+    return {
+        "code": 0,
+        "msg": "success",
+        "data": {"username": username, "role": "user"},
+    }
+
+
+def _success_payload() -> dict[str, object]:
+    return {"code": 0, "msg": "success", "data": None}
+
+
+def _prepare_client(
+    *,
+    hardware: HWVersion = HWVersion.PCIE,
+    application: str | None = "2.5.1",
+) -> NanoKVMClient:
+    client = NanoKVMClient(
+        _BASE_URL,
+        token="session-token",
+        use_password_obfuscation=True,
+    )
+    client._hw_version = hardware
+    client._application_version = application
+    return client
+
+
+async def test_new_contract_sends_both_obfuscated_passwords_and_clears_session() -> (
+    None
+):
+    """2.5.1 changes the authenticated user's password and invalidates sessions."""
+    client = _prepare_client()
+    client._use_password_obfuscation = False
+    mock_ws = AsyncMock()
+    mock_ws.closed = False
+
+    async with client:
+        client._ws = mock_ws
+        client._mouse_buttons = 1
+        with (
+            aioresponses() as mocked,
+            patch(
+                "nanokvm.client.obfuscate_password",
+                side_effect=lambda value: f"encoded-{value}",
+            ),
+        ):
+            mocked.get(_ACCOUNT_URL, payload=_account_payload())
+            mocked.post(_PASSWORD_URL, payload=_success_payload())
+
+            await client.change_password(
+                "synthetic-user",
+                "new-password",
+                current_password="current-password",
+            )
+
+            calls = mocked.requests[("POST", yarl.URL(_PASSWORD_URL))]
+            assert calls[0].kwargs.get("json") == {
+                "currentPassword": "encoded-current-password",
+                "password": "encoded-new-password",
+            }
+            assert client.token is None
+            assert client._mouse_buttons == 0
+            mock_ws.close.assert_awaited_once()
+            assert client._ws is None
+
+
+async def test_new_contract_requires_current_password_before_sending() -> None:
+    """A 2.5.1 change cannot be attempted without the current password."""
+    async with _prepare_client() as client:
+        with pytest.raises(ValueError, match="current_password"):
+            await client.change_password("synthetic-user", "new-password")
+
+
+async def test_new_contract_rejects_a_different_authenticated_username() -> None:
+    """The body username cannot be used to change another account's password."""
+    async with _prepare_client() as client:
+        with aioresponses() as mocked:
+            mocked.get(_ACCOUNT_URL, payload=_account_payload("authenticated-user"))
+
+            with pytest.raises(ValueError, match="authenticated account"):
+                await client.change_password(
+                    "other-user",
+                    "new-password",
+                    current_password="current-password",
+                )
+
+            assert ("POST", yarl.URL(_PASSWORD_URL)) not in mocked.requests
+
+
+async def test_new_contract_preserves_api_error_codes() -> None:
+    """An incorrect current password remains a device API error."""
+    async with _prepare_client() as client:
+        with aioresponses() as mocked:
+            mocked.get(_ACCOUNT_URL, payload=_account_payload())
+            mocked.post(
+                _PASSWORD_URL,
+                payload={"code": -3, "msg": "current password incorrect", "data": None},
+            )
+
+            with pytest.raises(NanoKVMApiError) as exc_info:
+                await client.change_password(
+                    "synthetic-user",
+                    "new-password",
+                    current_password="wrong-password",
+                )
+
+            assert exc_info.value.code == -3
+            assert client.token == "session-token"
+
+
+@pytest.mark.parametrize(
+    ("hardware", "application"),
+    [
+        (HWVersion.PCIE, "2.5.0"),
+        (HWVersion.PRO, "1.2.15"),
+    ],
+)
+async def test_legacy_contract_is_preserved_for_old_and_pro_devices(
+    hardware: HWVersion,
+    application: str,
+) -> None:
+    """Older non-Pro firmware and Pro keep the username/password request."""
+    async with _prepare_client(hardware=hardware, application=application) as client:
+        with (
+            aioresponses() as mocked,
+            patch(
+                "nanokvm.client.obfuscate_password",
+                side_effect=lambda value: f"encoded-{value}",
+            ),
+        ):
+            mocked.post(_PASSWORD_URL, payload=_success_payload())
+
+            await client.change_password("synthetic-user", "new-password")
+
+            calls = mocked.requests[("POST", yarl.URL(_PASSWORD_URL))]
+            assert calls[0].kwargs.get("json") == {
+                "username": "synthetic-user",
+                "password": "encoded-new-password",
+            }
+            assert ("GET", yarl.URL(_ACCOUNT_URL)) not in mocked.requests
+
+
+async def test_legacy_contract_preserves_plain_text_password_mode() -> None:
+    """The old contract still honors an explicitly selected plain mode."""
+    client = _prepare_client(hardware=HWVersion.PCIE, application="2.5.0")
+    client._use_password_obfuscation = False
+
+    async with client:
+        with aioresponses() as mocked:
+            mocked.post(_PASSWORD_URL, payload=_success_payload())
+
+            await client.change_password("synthetic-user", "new-password")
+
+            calls = mocked.requests[("POST", yarl.URL(_PASSWORD_URL))]
+            assert calls[0].kwargs.get("json") == {
+                "username": "synthetic-user",
+                "password": "new-password",
+            }
+
+
+async def test_unknown_application_version_is_not_guessed() -> None:
+    """A missing version produces an actionable error instead of guessing."""
+    async with _prepare_client(application=None) as client:
+        with patch.object(
+            client, "detect_versions", new_callable=AsyncMock
+        ) as detect_versions:
+            with pytest.raises(NanoKVMError, match="Application version"):
+                await client.change_password(
+                    "synthetic-user",
+                    "new-password",
+                    current_password="current-password",
+                )
+
+            detect_versions.assert_awaited_once()
+
+
+async def test_custom_application_version_is_not_guessed() -> None:
+    """A development version without a comparable number uses neither contract."""
+    async with _prepare_client(application="development") as client:
+        with pytest.raises(NanoKVMError, match="Application version"):
+            await client.change_password(
+                "synthetic-user",
+                "new-password",
+                current_password="current-password",
+            )
+
+
+async def test_password_change_detects_hardware_and_version_when_needed() -> None:
+    """An authenticated client can identify the contract through /vm endpoints."""
+    async with _prepare_client(hardware=HWVersion.UNKNOWN, application=None) as client:
+        client._hw_version = None
+        with (
+            aioresponses() as mocked,
+            patch(
+                "nanokvm.client.obfuscate_password",
+                side_effect=lambda value: f"encoded-{value}",
+            ),
+        ):
+            mocked.get(
+                f"{_BASE_URL}vm/hardware",
+                payload={"code": 0, "msg": "success", "data": {"version": "PCIE"}},
+            )
+            mocked.get(
+                f"{_BASE_URL}vm/info",
+                payload={
+                    "code": 0,
+                    "msg": "success",
+                    "data": {
+                        "ips": [],
+                        "mdns": "kvm.local",
+                        "image": "v1.4.0",
+                        "application": "2.5.1",
+                        "deviceKey": "synthetic-device-key",
+                    },
+                },
+            )
+            mocked.get(_ACCOUNT_URL, payload=_account_payload())
+            mocked.post(_PASSWORD_URL, payload=_success_payload())
+
+            await client.change_password(
+                "synthetic-user",
+                "new-password",
+                current_password="current-password",
+            )
+
+            assert client.token is None


### PR DESCRIPTION
## Problem

NanoKVM 2.5.1 changes the password endpoint contract for non-Pro devices. It requires the current password, expects both passwords in obfuscated form, and changes the password of the authenticated account.

## Changes

- Extend `change_password()` with the keyword-only `current_password` argument.
- Use the new contract for non-Pro firmware version 2.5.1 and newer.
- Preserve the existing contract for older non-Pro firmware and NanoKVM Pro.
- Require a non-empty current password for the new contract.
- Verify that the requested username matches the authenticated account.
- Send only `currentPassword` and `password` in the new payload.
- Obfuscate both password values independently.
- Clear the local session after a successful password change.
- Do not store the password or authenticate automatically afterward.
- Preserve API error codes such as an incorrect current password.
- Return an explicit error when the application version cannot be identified.
- Document the updated method signature in the README.

## Validation

- `pre-commit run --all-files`
- `pytest -n auto --timeout=20 --cov=nanokvm --cov-fail-under=62`
- 122 tests passed with 87.19% coverage.
- Regression tests cover exact legacy and new payloads, missing current passwords, account mismatches, API errors, Pro compatibility, and unknown versions.
- No password was changed on a real device; real-device validation for this branch remained read-only.