### PR TITLE
Isolate NanoKVM session cookies across shared HTTP clients

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import AsyncIterator, Callable, Coroutine
 import contextlib
 import functools
+from http.cookies import Morsel
 import io
 import json
 import logging
@@ -463,6 +464,7 @@ class NanoKVMClient:
         assert self._session is not None
         assert self._ssl_config is not None
 
+        self._clear_session_cookies()
         request_headers = {
             hdrs.ACCEPT: "application/json",
             **kwargs.pop("headers", {}),
@@ -478,6 +480,9 @@ class NanoKVMClient:
             ssl=self._ssl_config,
             **kwargs,
         ) as response:
+            # The explicit token owns the session. Do not leave response cookies
+            # available to another client sharing this HTTP session.
+            self._clear_session_cookies()
             if authenticate and response.status == 401:
                 await self._clear_local_session()
                 raise NanoKVMNotAuthenticatedError(
@@ -763,7 +768,30 @@ class NanoKVMClient:
         """Clear local authentication and transport state without closing HTTP."""
         self._token = None
         self._mouse_buttons = 0
+        self._clear_session_cookies()
         await self._close_ws()
+
+    def _clear_session_cookies(self) -> None:
+        """Remove only session cookies whose scope overlaps this device's API."""
+        if self._session is None:
+            return
+        host = self.url.raw_host or ""
+        base_path = self.url.path.rstrip("/")
+
+        def is_device_session(cookie: Morsel[str]) -> bool:
+            if cookie.key != _SESSION_COOKIE_NAME:
+                return False
+            domain = cookie["domain"].lstrip(".")
+            if domain and host != domain and not host.endswith(f".{domain}"):
+                return False
+            path = cookie["path"].rstrip("/")
+            return (
+                base_path == path
+                or base_path.startswith(f"{path}/")
+                or path.startswith(f"{base_path}/")
+            )
+
+        self._session.cookie_jar.clear(is_device_session)
 
     async def _uses_current_password_contract(self) -> bool:
         """Determine whether this device uses the 2.5.1 password contract."""
@@ -1985,11 +2013,15 @@ class NanoKVMClient:
                 assert self._session is not None
                 assert self._ssl_config is not None
 
+                # ws_connect has no per-request cookies argument, and aiohttp's
+                # jar would otherwise override the explicit Cookie header.
+                self._clear_session_cookies()
                 self._ws = await self._session.ws_connect(
                     str(ws_url),
                     headers={"Cookie": f"nano-kvm-token={self._token}"},
                     ssl=self._ssl_config,
                 )
+                self._clear_session_cookies()
                 return self._ws
         except aiohttp.ClientResponseError as err:
             method = getattr(err.request_info, "method", hdrs.METH_GET)

--- a/tests/test_session_isolation.py
+++ b/tests/test_session_isolation.py
@@ -1,0 +1,166 @@
+"""Exercise session ownership against an actual HTTP/WebSocket server."""
+
+from collections.abc import AsyncIterator
+import io
+
+import aiohttp
+from aiohttp import web
+from PIL import Image
+import pytest
+import yarl
+
+from nanokvm.client import NanoKVMClient
+
+
+@pytest.fixture
+async def session_server() -> AsyncIterator[str]:
+    """Return a local device URL; never send input or modify a real device."""
+
+    async def login(request: web.Request) -> web.Response:
+        data = await request.json()
+        response = web.json_response({"code": 0, "msg": "ok", "data": None})
+        response.set_cookie("nano-kvm-token", data["username"], httponly=True)
+        return response
+
+    async def hardware(request: web.Request) -> web.Response:
+        return web.json_response({"code": 0, "msg": "ok", "data": {"version": "PCIE"}})
+
+    async def account(request: web.Request) -> web.Response:
+        return web.json_response(
+            {
+                "code": 0,
+                "msg": "ok",
+                "data": {
+                    "username": request.cookies.get("nano-kvm-token", "anonymous")
+                },
+            }
+        )
+
+    async def websocket(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.send_str(request.cookies.get("nano-kvm-token", "anonymous"))
+        async for _ in ws:
+            pass
+        return ws
+
+    async def stream(request: web.Request) -> web.Response:
+        image = io.BytesIO()
+        width = 2 if request.cookies.get("nano-kvm-token") == "reader" else 3
+        Image.new("RGB", (width, 2)).save(image, format="JPEG")
+        return web.Response(
+            body=b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+            + image.getvalue()
+            + b"\r\n--frame--\r\n",
+            headers={"Content-Type": "multipart/x-mixed-replace; boundary=frame"},
+        )
+
+    async def logout(request: web.Request) -> web.Response:
+        return web.Response(status=503)
+
+    app = web.Application()
+    app.router.add_post("/api/auth/login", login)
+    app.router.add_post("/api/auth/logout", logout)
+    app.router.add_get("/api/vm/hardware", hardware)
+    app.router.add_get("/api/auth/account", account)
+    app.router.add_get("/api/ws", websocket)
+    app.router.add_get("/api/stream/mjpeg", stream)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = runner.addresses[0][1]
+        yield f"http://localhost:{port}/api/"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.parametrize("jar_kind", ["normal", "dummy", "ip"])
+async def test_shared_http_session_keeps_each_client_identity(
+    session_server: str, jar_kind: str
+) -> None:
+    """A second login must not replace the first client's WebSocket identity."""
+    jar = (
+        aiohttp.DummyCookieJar()
+        if jar_kind == "dummy"
+        else aiohttp.CookieJar(unsafe=jar_kind == "ip")
+    )
+    url = (
+        session_server.replace("localhost", "127.0.0.1")
+        if jar_kind == "ip"
+        else session_server
+    )
+    async with aiohttp.ClientSession(cookie_jar=jar) as session:
+        async with (
+            NanoKVMClient(url, session=session) as reader,
+            NanoKVMClient(url, session=session) as admin,
+        ):
+            await reader.authenticate("reader", "synthetic-password")
+            await admin.authenticate("admin", "synthetic-password")
+            assert (await reader.get_account()).username == "reader"
+            ws = await reader._get_ws()
+            assert await ws.receive_str() == "reader"
+            async for frame in reader.mjpeg_stream():
+                assert frame.size == (2, 2)
+            assert (await admin.get_account()).username == "admin"
+        assert not session.closed
+
+
+@pytest.mark.parametrize("token", ["reader", "disabled"])
+async def test_explicit_websocket_token_overrides_stale_cookie(
+    session_server: str, token: str
+) -> None:
+    """Externally supplied tokens also take precedence, including disabled auth."""
+    async with aiohttp.ClientSession() as session:
+        session.cookie_jar.update_cookies(
+            {"nano-kvm-token": "stale"}, yarl.URL(session_server)
+        )
+        async with NanoKVMClient(
+            session_server, session=session, token=token
+        ) as client:
+            ws = await client._get_ws()
+            assert await ws.receive_str() == token
+
+
+async def test_failed_logout_removes_only_device_session_cookies(
+    session_server: str,
+) -> None:
+    """Network failure must not leave implicit credentials in an external jar."""
+    async with aiohttp.ClientSession() as session:
+        jar = session.cookie_jar
+        jar.update_cookies({"preference": "dark"}, yarl.URL(session_server))
+        jar.update_cookies(
+            {"nano-kvm-token": "other-device"}, yarl.URL("http://other.local/")
+        )
+        jar.update_cookies(
+            {"nano-kvm-token": "other-service"},
+            yarl.URL(session_server) / "../../unrelated/page",
+        )
+        async with NanoKVMClient(
+            session_server, session=session, token="reader"
+        ) as client:
+            jar.update_cookies(
+                {"nano-kvm-token": "old-session"}, yarl.URL(session_server)
+            )
+            with pytest.raises(aiohttp.ClientResponseError):
+                await client.logout()
+            assert client.token is None
+            assert "nano-kvm-token" not in jar.filter_cookies(yarl.URL(session_server))
+            assert (
+                jar.filter_cookies(yarl.URL(session_server))["preference"].value
+                == "dark"
+            )
+            assert (
+                jar.filter_cookies(yarl.URL("http://other.local/"))[
+                    "nano-kvm-token"
+                ].value
+                == "other-device"
+            )
+            assert (
+                jar.filter_cookies(
+                    yarl.URL(session_server).with_path("/unrelated/page")
+                )["nano-kvm-token"].value
+                == "other-service"
+            )
+        assert not session.closed


### PR DESCRIPTION
## Summary

When multiple `NanoKVMClient` instances share an `aiohttp.ClientSession`, the shared cookie jar can override an explicit NanoKVM token during WebSocket requests or preserve a stale device cookie after logout.

## Changes

- Remove only `nano-kvm-token` cookies scoped to the current device.
- Keep cookies from other hosts, paths, and services intact.
- Preserve externally supplied sessions without closing them.
- Ensure the explicit client token remains authoritative for WebSocket requests.
- Add regression tests for shared sessions, normal and dummy cookie jars, IP and hostname URLs, stale cookies, and failed logout cleanup.

## Validation

- All pre-commit hooks passed.
- 128 tests passed.
- Coverage remained above the project minimum.