### PR TITLE
Clear stale NanoKVM identity before reauthentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ async with NanoKVMClient("https://kvm.local/api/") as client:
 
 ### Account roles and permissions
 
+Calling `authenticate()` clears the previous local session and input state before
+attempting a new login. If that login fails, the client stays unauthenticated.
+
 `get_account()` exposes the optional `role` returned by newer firmware. The
 value is a string so unknown future roles remain readable; older firmware may
 return `None`. A logged-in account can receive `NanoKVMPermissionError` when a

--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -717,9 +717,6 @@ class NanoKVMClient:
                     "Authentication response missing token."
                 )
 
-            if self._token != token:
-                await self._close_ws()
-                self._mouse_buttons = 0
             self._token = token
         except NanoKVMApiError as err:
             if err.code == ApiResponseCode.INVALID_USERNAME_OR_PASSWORD.value:
@@ -731,6 +728,8 @@ class NanoKVMClient:
 
     async def authenticate(self, username: str, password: str) -> None:
         """Authenticate and store the session token."""
+        # A failed identity switch must never leave the previous account usable.
+        await self._clear_local_session()
         _LOGGER.debug("Attempting authentication for user: %s", username)
 
         if self._use_password_obfuscation is True:

--- a/tests/test_session_cookie_auth.py
+++ b/tests/test_session_cookie_auth.py
@@ -15,6 +15,7 @@ from nanokvm.client import (
     NanoKVMAuthenticationFailure,
     NanoKVMClient,
     NanoKVMInvalidResponseError,
+    NanoKVMNotAuthenticatedError,
 )
 from nanokvm.models import HWVersion
 
@@ -170,7 +171,63 @@ async def test_empty_login_response_is_not_authentication_disabled() -> None:
             with pytest.raises(NanoKVMInvalidResponseError, match="missing token"):
                 await client.authenticate("synthetic-user", "synthetic-password")
 
-            assert client.token == "disabled"
+            assert client.token is None
+
+
+@pytest.mark.parametrize("failure", ["credentials", "forbidden", "format", "network"])
+async def test_failed_reauthentication_cannot_keep_previous_identity(
+    failure: str,
+) -> None:
+    """A failed identity switch must not retain an old privileged session."""
+    old_ws = AsyncMock()
+    old_ws.closed = False
+    async with NanoKVMClient(
+        _BASE_URL, token="previous-admin", use_password_obfuscation=True
+    ) as client:
+        client._ws = old_ws
+        client._mouse_buttons = 1
+        with aioresponses() as mocked:
+            if failure == "credentials":
+                mocked.post(
+                    _LOGIN_URL, payload={"code": -2, "msg": "invalid", "data": None}
+                )
+                error: type[Exception] = NanoKVMAuthenticationFailure
+            elif failure == "forbidden":
+                mocked.post(_LOGIN_URL, status=403, body='"forbidden"')
+                error = aiohttp.ClientResponseError
+            elif failure == "network":
+                mocked.post(_LOGIN_URL, exception=aiohttp.ClientConnectionError())
+                error = aiohttp.ClientConnectionError
+            else:
+                mocked.post(_LOGIN_URL, payload=_login_payload())
+                error = NanoKVMInvalidResponseError
+            with pytest.raises(error):
+                await client.authenticate("other-user", "synthetic-password")
+            assert client.token is None
+            assert client._mouse_buttons == 0
+            old_ws.close.assert_awaited_once()
+            with pytest.raises(NanoKVMNotAuthenticatedError):
+                await client.get_account()
+            with pytest.raises(NanoKVMNotAuthenticatedError):
+                await client._get_ws()
+            assert len(mocked.requests[("POST", yarl.URL(_LOGIN_URL))]) == 1
+
+
+async def test_reauthentication_clears_transport_even_when_token_is_reissued() -> None:
+    """Transport state belongs to an authentication attempt, not a token string."""
+    old_ws = AsyncMock()
+    old_ws.closed = False
+    async with NanoKVMClient(_BASE_URL, token="same-token") as client:
+        client._ws = old_ws
+        client._mouse_buttons = 1
+        with aioresponses() as mocked:
+            mocked.post(_LOGIN_URL, payload=_login_payload({"token": "same-token"}))
+            mocked.get(_HARDWARE_URL, payload=_HARDWARE_PAYLOAD)
+            await client.authenticate("synthetic-user", "synthetic-password")
+        assert client.token == "same-token"
+        assert client._ws is None
+        assert client._mouse_buttons == 0
+        old_ws.close.assert_awaited_once()
 
 
 async def test_authentication_uses_received_token_for_http_requests() -> None:


### PR DESCRIPTION
## Summary

A failed reauthentication could leave the previous NanoKVM identity active, including its token, WebSocket connection, and pressed-button state.

## Changes

- Clear the local session before every new authentication attempt.
- Close the previous WebSocket and reset mouse-button state before switching identities.
- Keep the client unauthenticated when the new login fails.
- Reset transport state even when the device issues the same token again.
- Add regression tests covering credential errors, forbidden responses, malformed responses, network failures, and token reuse.

## Validation

- All pre-commit hooks passed.
- 133 tests passed.
- Coverage: 87%.