### PR TITLE
Prevent stale responses from invalidating new NanoKVM sessions

### DIFF
--- a/nanokvm/client.py
+++ b/nanokvm/client.py
@@ -341,6 +341,7 @@ class NanoKVMClient:
         self._session: ClientSession | None = session
         self._external_session_provided = session is not None
         self._token = token
+        self._session_generation = 0
         self._request_timeout = request_timeout
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._ws_lock = asyncio.Lock()
@@ -455,6 +456,7 @@ class NanoKVMClient:
         **kwargs: Any,
     ) -> AsyncIterator[ClientResponse]:
         """Make an API request."""
+        generation = self._session_generation
         cookies = {}
         if authenticate:
             if not self._token:
@@ -484,7 +486,7 @@ class NanoKVMClient:
             # available to another client sharing this HTTP session.
             self._clear_session_cookies()
             if authenticate and response.status == 401:
-                await self._clear_local_session()
+                await self._clear_local_session(expected_generation=generation)
                 raise NanoKVMNotAuthenticatedError(
                     "NanoKVM session is no longer authenticated"
                 )
@@ -757,18 +759,33 @@ class NanoKVMClient:
 
     async def logout(self) -> None:
         """Log out and clear the session token."""
+        generation = self._session_generation
         try:
             if self._token and self._token != "disabled":
                 await self._api_request_json(hdrs.METH_POST, "/auth/logout")
         finally:
-            await self._clear_local_session()
+            await self._clear_local_session(expected_generation=generation)
 
-    async def _clear_local_session(self) -> None:
+    async def _clear_local_session(
+        self, *, expected_generation: int | None = None
+    ) -> None:
         """Clear local authentication and transport state without closing HTTP."""
-        self._token = None
-        self._mouse_buttons = 0
-        self._clear_session_cookies()
-        await self._close_ws()
+        async with self._ws_lock:
+            if (
+                expected_generation is not None
+                and expected_generation != self._session_generation
+            ):
+                return
+            self._session_generation += 1
+            self._token = None
+            self._mouse_buttons = 0
+            self._clear_session_cookies()
+            ws = self._ws
+            self._ws = None
+        # Detach state atomically, then close only the old transport. Network I/O
+        # must not block a new login or close its replacement WebSocket.
+        if ws is not None and not ws.closed:
+            await ws.close()
 
     def _clear_session_cookies(self) -> None:
         """Remove only session cookies whose scope overlaps this device's API."""
@@ -841,6 +858,7 @@ class NanoKVMClient:
                     "username must match the authenticated account on NanoKVM 2.5.1"
                 )
 
+            generation = self._session_generation
             await self._api_request_json(
                 hdrs.METH_POST,
                 "/auth/password",
@@ -849,7 +867,7 @@ class NanoKVMClient:
                     password=obfuscate_password(new_password),
                 ),
             )
-            await self._clear_local_session()
+            await self._clear_local_session(expected_generation=generation)
             return
 
         if self._use_password_obfuscation is None:
@@ -1993,6 +2011,7 @@ class NanoKVMClient:
 
     async def _get_ws(self) -> aiohttp.ClientWebSocketResponse:
         """Get or create WebSocket connection for mouse events."""
+        generation = self._session_generation
         try:
             async with self._ws_lock:
                 if self._ws is not None and not self._ws.closed:
@@ -2004,6 +2023,8 @@ class NanoKVMClient:
 
                 if not self._token:
                     raise NanoKVMNotAuthenticatedError("Client is not authenticated")
+
+                generation = self._session_generation
 
                 # WebSocket URL uses ws:// or wss:// scheme
                 scheme = "ws" if self.url.scheme == "http" else "wss"
@@ -2027,7 +2048,7 @@ class NanoKVMClient:
             if err.status == 401:
                 # _clear_local_session acquires _ws_lock, so do this after the
                 # lock above has been released to avoid a self-deadlock.
-                await self._clear_local_session()
+                await self._clear_local_session(expected_generation=generation)
                 raise NanoKVMNotAuthenticatedError(
                     "NanoKVM session is no longer authenticated"
                 ) from err

--- a/tests/test_session_generation.py
+++ b/tests/test_session_generation.py
@@ -1,0 +1,211 @@
+"""Concurrent responses must only invalidate the session that sent them."""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+from aioresponses import CallbackResult, aioresponses
+from multidict import CIMultiDict, CIMultiDictProxy
+import pytest
+import yarl
+
+from nanokvm.client import NanoKVMClient, NanoKVMNotAuthenticatedError
+from nanokvm.models import HWVersion
+
+_URL = "http://kvm.local/api/"
+
+
+@pytest.mark.parametrize("transport", ["json", "form", "mjpeg"])
+@pytest.mark.parametrize("new_token", ["new-session", "old-session"])
+async def test_delayed_401_does_not_clear_replacement_session(
+    transport: str,
+    new_token: str,
+) -> None:
+    """Even an identical reissued token belongs to a new login generation."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed_401(*args: object, **kwargs: object) -> CallbackResult:
+        started.set()
+        await release.wait()
+        return CallbackResult(status=401, body='"unauthorized"')
+
+    async with NanoKVMClient(_URL, token="old-session") as client:
+
+        async def request() -> None:
+            if transport == "json":
+                await client.get_account()
+            elif transport == "form":
+                await client._api_request_form(
+                    "POST", "/upload", data=aiohttp.FormData()
+                )
+            else:
+                async for _ in client.mjpeg_stream():
+                    pass
+
+        with aioresponses() as mocked:
+            if transport == "json":
+                mocked.get(f"{_URL}auth/account", callback=delayed_401)
+            elif transport == "form":
+                mocked.post(f"{_URL}upload", callback=delayed_401)
+            else:
+                mocked.get(f"{_URL}stream/mjpeg", callback=delayed_401)
+            mocked.post(
+                f"{_URL}auth/login",
+                payload={"code": 0, "msg": "ok", "data": {"token": new_token}},
+            )
+            mocked.get(
+                f"{_URL}vm/hardware",
+                payload={"code": 0, "msg": "ok", "data": {"version": "PCIE"}},
+            )
+            async with asyncio.timeout(2):
+                pending = asyncio.create_task(request())
+                await started.wait()
+                try:
+                    await client.authenticate("synthetic-user", "synthetic-password")
+                finally:
+                    release.set()
+                with pytest.raises(NanoKVMNotAuthenticatedError):
+                    await pending
+            assert client.token == new_token
+
+
+async def test_websocket_401_waiting_for_cleanup_cannot_clear_new_login() -> None:
+    """Model another login winning the lock before handshake cleanup runs."""
+    cleanup_started = asyncio.Event()
+    release = asyncio.Event()
+    error = aiohttp.WSServerHandshakeError(
+        aiohttp.RequestInfo(
+            yarl.URL(_URL + "ws"), "GET", CIMultiDictProxy(CIMultiDict())
+        ),
+        (),
+        status=401,
+    )
+    async with NanoKVMClient(_URL, token="old-session") as client:
+        original_clear = client._clear_local_session
+
+        async def delayed_clear(*args: Any, **kwargs: Any) -> None:
+            if asyncio.current_task() is pending:
+                cleanup_started.set()
+                await release.wait()
+            await original_clear(*args, **kwargs)
+
+        with (
+            patch.object(client, "_clear_local_session", side_effect=delayed_clear),
+            patch("aiohttp.ClientSession.ws_connect", AsyncMock(side_effect=error)),
+            aioresponses() as mocked,
+        ):
+            mocked.post(
+                f"{_URL}auth/login",
+                payload={"code": 0, "msg": "ok", "data": {"token": "new-session"}},
+            )
+            mocked.get(
+                f"{_URL}vm/hardware",
+                payload={"code": 0, "msg": "ok", "data": {"version": "PCIE"}},
+            )
+            pending = asyncio.create_task(client._get_ws())
+            async with asyncio.timeout(2):
+                await cleanup_started.wait()
+                try:
+                    await client.authenticate("synthetic-user", "synthetic-password")
+                finally:
+                    release.set()
+                with pytest.raises(NanoKVMNotAuthenticatedError):
+                    await pending
+            assert client.token == "new-session"
+
+
+async def test_session_cleanup_does_not_close_new_websocket_while_old_one_closes() -> (
+    None
+):
+    """Closing an old socket must not hold up or dispose of a replacement."""
+    closing = asyncio.Event()
+    finish_close = asyncio.Event()
+
+    async def close_old() -> None:
+        closing.set()
+        await finish_close.wait()
+
+    async with NanoKVMClient(_URL, token="old-session") as client:
+        old_ws = AsyncMock(closed=False)
+        old_ws.close.side_effect = close_old
+        client._ws = old_ws
+        cleanup = asyncio.create_task(client._clear_local_session())
+        async with asyncio.timeout(2):
+            await closing.wait()
+            try:
+                with aioresponses() as mocked:
+                    mocked.post(
+                        f"{_URL}auth/login",
+                        payload={
+                            "code": 0,
+                            "msg": "ok",
+                            "data": {"token": "new-session"},
+                        },
+                    )
+                    mocked.get(
+                        f"{_URL}vm/hardware",
+                        payload={"code": 0, "msg": "ok", "data": {"version": "PCIE"}},
+                    )
+                    await client.authenticate("synthetic-user", "synthetic-password")
+                new_ws = AsyncMock(closed=False)
+                with patch(
+                    "aiohttp.ClientSession.ws_connect", AsyncMock(return_value=new_ws)
+                ):
+                    assert await client._get_ws() is new_ws
+            finally:
+                finish_close.set()
+                await cleanup
+            assert client.token == "new-session"
+            assert client._ws is new_ws
+            new_ws.close.assert_not_awaited()
+
+
+@pytest.mark.parametrize("operation", ["logout", "password"])
+async def test_delayed_session_ending_response_keeps_new_login(operation: str) -> None:
+    """Successful logout/password responses belong to the sending session too."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed_success(*args: object, **kwargs: object) -> CallbackResult:
+        started.set()
+        await release.wait()
+        return CallbackResult(payload={"code": 0, "msg": "ok", "data": None})
+
+    async with NanoKVMClient(_URL, token="old-session") as client:
+        client._hw_version = HWVersion.PCIE
+        client._application_version = "2.5.1"
+        with aioresponses() as mocked:
+            mocked.get(
+                f"{_URL}auth/account",
+                payload={
+                    "code": 0,
+                    "msg": "ok",
+                    "data": {"username": "synthetic-user"},
+                },
+            )
+            mocked.post(f"{_URL}auth/{operation}", callback=delayed_success)
+            mocked.post(
+                f"{_URL}auth/login",
+                payload={"code": 0, "msg": "ok", "data": {"token": "new-session"}},
+            )
+            mocked.get(
+                f"{_URL}vm/hardware",
+                payload={"code": 0, "msg": "ok", "data": {"version": "PCIE"}},
+            )
+            pending = asyncio.create_task(
+                client.logout()
+                if operation == "logout"
+                else client.change_password(
+                    "synthetic-user", "new-password", current_password="old-password"
+                )
+            )
+            async with asyncio.timeout(2):
+                await started.wait()
+                try:
+                    await client.authenticate("synthetic-user", "synthetic-password")
+                finally:
+                    release.set()
+                await pending
+            assert client.token == "new-session"


### PR DESCRIPTION
## Summary

A delayed response from an older session could clear the token of a newer session after reauthentication.

## Changes

- Associate requests and WebSocket handshakes with a session generation.
- Ignore HTTP 401 invalidation responses belonging to an outdated session.
- Prevent delayed logout or password-change cleanup from clearing a replacement session.
- Detach the previous WebSocket before awaiting its close operation.
- Add regression tests covering JSON, multipart, MJPEG, WebSocket, logout, password changes, token reuse, and concurrent session replacement.

## Validation

- All pre-commit hooks passed.
- 143 tests passed.
- Coverage: 87%.